### PR TITLE
docs: record v1.0.0 release evidence

### DIFF
--- a/docs/VALIDATION.md
+++ b/docs/VALIDATION.md
@@ -1,8 +1,8 @@
 # Validation evidence
 
 This page is the evidence record for release candidates. Local evidence was
-reproduced on Windows on 2026-07-30. The linked public workflows ran against
-commit `ed7fd60f570deca1ed11567c9ce7a0967b57f046`.
+reproduced on Windows on 2026-07-30. The linked release-candidate workflows ran
+against tagged commit `304986f24b8d3bdb544c8ee97e70134c8c278c00`.
 
 ## Reproduce locally
 
@@ -30,18 +30,18 @@ python tools/mock_pack_matrix.py --pack pixel
 | Repository contract | Validator log with 85 skills, 49 roles, 12 hook behaviors, 11 rules, 40 templates, and 163 catalog records | **Pass locally** |
 | Official plugin validator | Seven validator logs from the pinned official Codex source | **7/7 pass locally** |
 | Official skill validator | 85 core logs plus optional-pack skill logs | **92/92 pass locally** |
-| Runtime unit tests | Windows, macOS, and Linux CI links | **62/62 pass locally and on all three hosted operating systems** in [CI run 30561154587](https://github.com/frabcd/codex-ai-game-studio/actions/runs/30561154587) |
-| Hook fixtures | Every supported event fixture on Windows and POSIX command paths | **9/9 pass on Windows, macOS, and Linux** in [CI run 30561154587](https://github.com/frabcd/codex-ai-game-studio/actions/runs/30561154587) |
-| Pack transaction mocks | Plan, confirmed apply, health check, disable, and rollback for five host packs on three OS runners | **15/15 pass** in [CI run 30561154587](https://github.com/frabcd/codex-ai-game-studio/actions/runs/30561154587) |
+| Runtime unit tests | Windows, macOS, and Linux CI links | **62/62 pass locally and on all three hosted operating systems** in [CI run 30561936522](https://github.com/frabcd/codex-ai-game-studio/actions/runs/30561936522) |
+| Hook fixtures | Every supported event fixture on Windows and POSIX command paths | **9/9 pass on Windows, macOS, and Linux** in [CI run 30561936522](https://github.com/frabcd/codex-ai-game-studio/actions/runs/30561936522) |
+| Pack transaction mocks | Plan, confirmed apply, health check, disable, and rollback for five host packs on three OS runners | **15/15 pass** in [CI run 30561936522](https://github.com/frabcd/codex-ai-game-studio/actions/runs/30561936522) |
 | Catalog offline fallback | Network-disabled test log and snapshot digest | **Pass locally**; 163 records, source SHA-256 `acdfbb53d66400127f68529e447cc22872a7bc71e5cd994b0f4e32b10c2355a6` |
 | Sprite fixture | Transparency, baseline, frame, loop, provenance, and preview evidence | **Pass locally** |
 | 3D/PBR fixture | Topology, normals, UV, texture channels, LOD, collision, budget, and multi-view evidence | **Pass locally** |
 | Animation fixture | Rig weights, root motion, foot sliding, loop continuity, and preview evidence | **Pass locally** |
 | Audio fixture | Peaks, loudness, loop seam, consent, and provenance evidence | **Pass locally** |
 | Scene/gameplay fixture | Navigation, lighting, reachable spawn, interaction smoke, frame time, draw calls, and screenshot regression | **Pass locally** |
-| Code scanning | Python and GitHub Actions CodeQL analyses | **2/2 pass** in [CodeQL run 30561154579](https://github.com/frabcd/codex-ai-game-studio/actions/runs/30561154579) |
-| Documentation deployment | Pages build and deployment with public legal/support routes | **Pass** in [Pages run 30561154570](https://github.com/frabcd/codex-ai-game-studio/actions/runs/30561154570) |
-| Deterministic release | Two independent build digests, `SHA256SUMS`, SPDX SBOM, and GitHub attestation | **11 files byte-identical locally**; hosted archives build on three operating systems; provenance attestation runs at tag publication |
+| Code scanning | Python and GitHub Actions CodeQL analyses | **2/2 pass** in [CodeQL run 30561936424](https://github.com/frabcd/codex-ai-game-studio/actions/runs/30561936424) |
+| Documentation deployment | Pages build and deployment with public legal/support routes | **Pass** in [Pages run 30561936448](https://github.com/frabcd/codex-ai-game-studio/actions/runs/30561936448); documentation, privacy, terms, and support routes return HTTP 200 |
+| Deterministic release | Two independent build digests, `SHA256SUMS`, SPDX SBOM, and GitHub attestation | **Pass** in [release run 30562203287](https://github.com/frabcd/codex-ai-game-studio/actions/runs/30562203287): 11 public assets, 10/10 checksum entries matched, and 11/11 provenance attestations present in [v1.0.0](https://github.com/frabcd/codex-ai-game-studio/releases/tag/v1.0.0) |
 | Clean installation | Codex CLI and Desktop marketplace install capture | **Pass** from the public `main` snapshot: version `1.0.0`, enabled, **85 skills discovered**; test plugin and marketplace then removed cleanly |
 
 ## Clean-install capture
@@ -58,6 +58,8 @@ version: 1.0.0
 enabled: true
 skillCount: 85
 explicitInvocation: AI_GAME_STUDIO_START_LOADED
+publicSnapshot: 304986f24b8d3bdb544c8ee97e70134c8c278c00
+bundleWarnings: 0
 cleanup marketplacePresent: false
 cleanup pluginPresent: false
 ```


### PR DESCRIPTION
## Summary

- point the validation ledger at the tagged release-candidate runs
- record public Pages health, checksum verification, and 11/11 provenance attestations
- record the zero-warning public marketplace snapshot used for the explicit skill smoke test

## Verification

- python tools/validate_repository.py
- python -m unittest tests.test_repository_contract tests.test_repository_pages -v
- v1.0.0 release workflow succeeded