### PR TITLE
fix: support independently cached platform editions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Run standard-library test suite
         run: python -m unittest discover -s tests -p "test_*.py" -v
       - name: Build deterministic artifacts
-        run: python tools/build_release.py --version 1.1.0 --output dist
+        run: python tools/build_release.py --version 1.1.1 --output dist
       - name: Upload Linux validation artifacts
         if: runner.os == 'Linux'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ permissions:
   attestations: write
 
 concurrency:
-  group: release-${{ github.ref }}-${{ inputs.version }}
+  group: release-${{ inputs.version || github.ref_name }}
   cancel-in-progress: false
 
 jobs:
@@ -63,6 +63,16 @@ jobs:
           git rev-parse --verify "refs/tags/$REQUESTED_TAG"
           echo "tag=$REQUESTED_TAG" >> "$GITHUB_OUTPUT"
           echo "version=${REQUESTED_TAG#v}" >> "$GITHUB_OUTPUT"
+      - name: Refuse an existing release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ steps.release.outputs.tag }}
+        run: |
+          if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
+            echo "Release $RELEASE_TAG already exists; refusing to replace immutable assets." >&2
+            exit 1
+          fi
       - name: Validate release candidate
         run: |
           python tools/validate_repository.py
@@ -87,8 +97,4 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_TAG: ${{ steps.release.outputs.tag }}
         run: |
-          if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
-            gh release upload "$RELEASE_TAG" dist/* --clobber
-          else
-            gh release create "$RELEASE_TAG" dist/* --verify-tag --generate-notes --title "Codex AI Game Studio $RELEASE_TAG"
-          fi
+          gh release create "$RELEASE_TAG" dist/* --verify-tag --generate-notes --title "Codex AI Game Studio $RELEASE_TAG"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 All notable changes are recorded here. The project follows Semantic Versioning.
 
+## [1.1.1] - 2026-07-31
+
+### Fixed
+
+- Windows and macOS edition launchers now hand their installed, read-only
+  descriptor to the matching core when Codex stores each plugin in an
+  independent marketplace cache directory. Version 1.1.0 worked in extracted
+  sibling layouts but could report `Available: none` after a public marketplace
+  install.
+- Added a real separate-cache launcher regression for both platform plugins.
+
+### Safety
+
+- The core accepts only an absolute `editions/<platform>.json` path inside a
+  matching MIT platform plugin with the exact core version, fixed identity and
+  target OS, scoped activation, and confirmation-gated adaptation rules.
+- Release archives must match every checked-in plugin and edition version.
+  Existing GitHub releases and assets are immutable; reruns fail before
+  validation, build, attestation, or upload instead of replacing files.
+
 ## [1.1.0] - 2026-07-31
 
 ### Added

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,7 +2,7 @@ cff-version: 1.2.0
 message: "If you use Codex AI Game Studio in research or production tooling, cite this software release."
 title: "Codex AI Game Studio"
 type: software
-version: 1.1.0
+version: 1.1.1
 date-released: 2026-07-31
 license: MIT
 authors:

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ otherwise compare verified Windows equivalents. Never claim binary
 compatibility, and wait for my transaction digest before changing anything.
 ```
 
-[Download the Windows v1.1.0 edition](https://github.com/frabcd/codex-ai-game-studio/releases/download/v1.1.0/codex-ai-game-studio-windows-v1.1.0.zip)
+[Download the Windows v1.1.1 edition](https://github.com/frabcd/codex-ai-game-studio/releases/download/v1.1.1/codex-ai-game-studio-windows-v1.1.1.zip)
 · [Windows tutorials](docs/platforms/windows.md)
 
 ### macOS
@@ -84,8 +84,12 @@ equivalents. Disclose Rosetta and hosted fallbacks, and wait for my transaction
 digest before changing anything.
 ```
 
-[Download the macOS v1.1.0 edition](https://github.com/frabcd/codex-ai-game-studio/releases/download/v1.1.0/codex-ai-game-studio-macos-v1.1.0.zip)
+[Download the macOS v1.1.1 edition](https://github.com/frabcd/codex-ai-game-studio/releases/download/v1.1.1/codex-ai-game-studio-macos-v1.1.1.zip)
 · [macOS tutorials](docs/platforms/macos.md)
+
+Use `v1.1.1` or later for marketplace-installed platform plugins. Version
+`v1.1.0` remains published for provenance but cannot hand an independently
+cached platform descriptor to the core.
 
 The edition ZIPs are convenience marketplaces, not preinstalled engines or
 models. A platform selection writes only transaction-listed project state; any

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -87,9 +87,13 @@ services remain separate proposals.
 
 Each platform plugin ships a native launcher plus a small Python resolver. The
 resolver accepts tokenized arguments, never invokes a shell, and locates the
-matching v1.1 core either beside an extracted edition or in the same Codex
-marketplace cache. A missing or version-mismatched core fails closed instead of
-falling through to an unrelated command on `PATH`.
+exact matching patch of the core either beside an extracted edition or in the
+same Codex marketplace cache. For independent Codex plugin caches, the launcher
+hands the core its own canonical, read-only descriptor path. The core accepts it
+only after validating the containing plugin manifest, exact version, platform
+identity, activation scope, and confirmation-gated rules. It never copies the
+descriptor. A missing or version-mismatched core fails closed instead of falling
+through to an unrelated command on `PATH`.
 
 ## Platform adaptation boundary
 

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -9,6 +9,26 @@
 
 Use `/plugins` to refresh the `frabcd-ai-game-studio` marketplace and update selected plugins. Start a new task afterward so skill and hook metadata reload.
 
+## Upgrade from 1.1.0 to 1.1.1
+
+Upgrade the core and the selected platform plugin together. This patch repairs
+edition descriptor discovery when Codex installs marketplace plugins into
+separate cache directories.
+
+```text
+codex plugin marketplace upgrade frabcd-ai-game-studio
+codex plugin add ai-game-studio@frabcd-ai-game-studio
+codex plugin add ai-game-studio-windows@frabcd-ai-game-studio
+# On macOS, install ai-game-studio-macos instead.
+```
+
+Confirm that both installed plugins report version `1.1.1`, start a new Codex
+task, and run the platform launcher's read-only `doctor` command. The patch does
+not change project or lock schemas and requires no project-state migration.
+Version 1.1.0 remains usable in an extracted sibling-layout edition, but its
+platform launcher cannot resolve the descriptor from Codex's independent public
+marketplace caches.
+
 ## Upgrade from 1.0.0 to 1.1.0
 
 The 1.1 release preserves the 85-skill core and schema version 1 project files.

--- a/docs/VALIDATION.md
+++ b/docs/VALIDATION.md
@@ -1,28 +1,40 @@
 # Validation evidence
 
-This page separates the current v1.1 release-candidate evidence from the
-published v1.0 historical record. Local v1.1 evidence was reproduced on Windows
-on 2026-07-31; hosted Windows, macOS, and Linux evidence will be linked after
-the candidate commit runs through CI.
+This page separates the current v1.1.1 hotfix candidate from the published
+v1.1.0 and v1.0.0 historical records. Local evidence was reproduced on Windows
+on 2026-07-31. Hosted and public-install evidence is updated only after the
+exact candidate commit runs.
 
-## v1.1 release-candidate record
+## v1.1.1 hotfix candidate record
 
 | Gate | Local evidence on 2026-07-31 | Status |
 |---|---|---|
 | Repository contract | 85 core skills, 95 bundled skills, 49 roles, 12 mapped hook behaviors, 11 rules, 40 upstream templates, 163 catalog records, two edition descriptors, and pinned img2threejs provenance | **Pass** |
-| Official plugin validator | Every marketplace plugin, including img2threejs, Windows, and macOS | **10/10 pass** |
-| Official skill validator | Core, automation, editor packs, img2threejs, Windows, and macOS skills | **95/95 pass** |
-| Runtime unit tests | Detection, transactions, rollback scope, offline routing, release archives, Pages, both edition launchers, security fixtures, and checkout-independent text normalization | **108/108 pass** |
-| Windows/macOS edition boundary | Repository and marketplace-cache launcher layouts; real host probes; OS mismatch rejection; digest-bound apply/disable/rollback; no external installation during edition selection | **Pass** |
-| img2threejs portability | Native Windows and macOS image-conversion routes, external user cache routing, and plugin-source write rejection | **Pass** |
-| img2threejs security | Public HTTPS allowlists, redirect and size limits, safe numeric outputs, preserve-existing behavior, hash-locked ImageMagick and Source2Viewer manifests, and bounded subprocesses | **Pass** |
+| Official validators | Every marketplace plugin and skill | **10/10 plugins and 95/95 skills pass** |
+| Runtime unit tests | Detection, transactions, rollback scope, offline routing, release archives, Pages, security, and real separate-cache edition launcher subprocesses | **113/113 pass locally** |
+| Installed edition boundary | Windows and macOS wrappers hand off only their canonical descriptor; core validates plugin identity, exact version, license, target OS, activation scope, and confirmation-gated rules; no copy or project-state write during doctor | **Pass** |
+| Clean local Codex installation | Installed the core, Windows edition, and img2threejs plugins through the marketplace CLI into independent `1.1.1` cache roots; discovered 85 + 1 + 1 skills; the installed Windows doctor exited 0 from an empty project with no state file, descriptor copy, or descriptor hash change; all test entries were then removed | **Pass** |
+| img2threejs portability and security | Native image conversion, external cache routing, CP1252-safe output, public HTTPS allowlists, download bounds, and hash-locked optional executables | **Pass** |
 | Documentation build | Legal/support, tutorials, img2threejs, Windows, and macOS routes plus rewritten internal links and copied assets | **43 files; zero broken internal links** |
 | Deterministic release | Two independent out-of-tree builds with identical filenames and SHA-256 values | **16/16 output files identical; 14 artifacts recorded** |
-| Extracted Windows edition installation | Add the packaged local marketplace, install core + Windows + img2threejs, run the installed native doctor, then remove all test state | **Pass; 85 + 1 + 1 skills, v1.1.0, read-only host match, clean removal** |
-| Hosted OS matrix | Windows, macOS, and Linux GitHub Actions | **Pending candidate push** |
-| Clean public installation | Marketplace install from the public v1.1 tag | **Pending candidate publication** |
+| Release immutability | Builder rejects a tag/package version mismatch; workflow serializes by requested tag and refuses an existing release before build or attestation | **Pass locally** |
+| Hosted OS matrix | Windows, macOS, and Linux GitHub Actions | **Pending hotfix push** |
+| Clean public installation | Marketplace install of core + matching platform + img2threejs from public `main` at v1.1.1 | **Pending hotfix publication** |
 
-### v1.1 extracted-edition capture
+## v1.1.0 published and affected record
+
+- Protected CI passed 109 tests on Windows, macOS, and Linux, all 15 pack jobs,
+  official validators, CodeQL, and dependency review in
+  [CI run 30603433632](https://github.com/frabcd/codex-ai-game-studio/actions/runs/30603433632).
+- [Release run 30603599328](https://github.com/frabcd/codex-ai-game-studio/actions/runs/30603599328)
+  published 16 checksummed and attested
+  [v1.1.0 assets](https://github.com/frabcd/codex-ai-game-studio/releases/tag/v1.1.0).
+- The extracted Windows edition sibling layout passed, but a clean public
+  marketplace install reproduced `Unknown edition 'windows'. Available: none`
+  with exit code 2 because Codex cached the platform and core plugins
+  independently. The failed read-only doctor created no project state.
+
+### v1.1.0 extracted-edition capture
 
 The Windows edition ZIP was expanded outside the repository and used exactly as
 a local marketplace. The test installed only the three plugins below, ran the
@@ -46,7 +58,7 @@ cleanup: complete
 python tools/validate_repository.py
 python tools/run_official_validators.py --require
 python -m unittest discover -s tests -p "test_*.py"
-python tools/build_release.py --version 1.1.0 --output dist
+python tools/build_release.py --version 1.1.1 --output dist
 ```
 
 Run the pack transaction smoke test once per pack:

--- a/docs/platforms/macos.md
+++ b/docs/platforms/macos.md
@@ -27,8 +27,11 @@ The workflow has five separate phases:
 The edition recognizes Darwin on `arm64` and `x86_64`, zsh/POSIX shells, Homebrew and MacPorts, Metal/MPS/Core ML/CPU, and Unity, Godot, Unreal, Blender, Aseprite, Pixelorama, and Tiled. Detection checks presence and metadata; it does not launch applications, update package managers, or read credential values.
 
 Resolve `<macos-plugin-root>` to the installed `ai-game-studio-macos` plugin.
-Its native launcher finds only a matching v1.1 core beside the extracted
-edition or in the same Codex marketplace cache:
+Its native launcher finds only the exact matching core patch beside the
+extracted edition or in the same Codex marketplace cache. When Codex caches the
+plugins independently, the launcher supplies its canonical descriptor path;
+the core validates the containing plugin identity, version, license, target OS,
+activation scope, and confirmation rules before reading it in place:
 
 ```text
 "<macos-plugin-root>/scripts/ai-game-studio-macos.sh" doctor --project <root>

--- a/docs/platforms/windows.md
+++ b/docs/platforms/windows.md
@@ -27,8 +27,12 @@ The workflow always uses this sequence:
 General approval is not digest confirmation. Preview-only requests stop after the proposal. Disabling or rolling back is a new transaction with a new digest.
 
 Resolve `<windows-plugin-root>` to the installed
-`ai-game-studio-windows` plugin. Its launcher finds only a matching v1.1 core
-beside the extracted edition or in the same Codex marketplace cache:
+`ai-game-studio-windows` plugin. Its launcher finds only the exact matching
+core patch beside the extracted edition or in the same Codex marketplace cache.
+When Codex caches the plugins independently, the launcher supplies its
+canonical descriptor path; the core validates the containing plugin identity,
+version, license, target OS, activation scope, and confirmation rules before
+reading it in place:
 
 ```text
 & "<windows-plugin-root>\scripts\ai-game-studio-windows.ps1" doctor --project <root>

--- a/plugins/ai-game-studio-automation/.codex-plugin/plugin.json
+++ b/plugins/ai-game-studio-automation/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-game-studio-automation",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Opt-in Codex lifecycle hooks, agent materialization, scoped AGENTS.md generation, and Claude-project migration for AI Game Studio.",
   "author": {
     "name": "frabcd",

--- a/plugins/ai-game-studio-blender/.codex-plugin/plugin.json
+++ b/plugins/ai-game-studio-blender/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-game-studio-blender",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "An opt-in, pinned Blender MCP adapter and safety workflow for Codex AI Game Studio.",
   "author": {"name": "frabcd", "url": "https://github.com/frabcd"},
   "homepage": "https://frabcd.github.io/codex-ai-game-studio/packs/blender/",

--- a/plugins/ai-game-studio-godot/.codex-plugin/plugin.json
+++ b/plugins/ai-game-studio-godot/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-game-studio-godot",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "An opt-in, pinned Godot MCP adapter and safety workflow for Codex AI Game Studio.",
   "author": {"name": "frabcd", "url": "https://github.com/frabcd"},
   "homepage": "https://frabcd.github.io/codex-ai-game-studio/packs/godot/",

--- a/plugins/ai-game-studio-img2threejs/.codex-plugin/plugin.json
+++ b/plugins/ai-game-studio-img2threejs/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-game-studio-img2threejs",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "A pinned, quality-gated image-to-procedural-Three.js workflow for Codex AI Game Studio.",
   "author": {
     "name": "frabcd",

--- a/plugins/ai-game-studio-macos/.codex-plugin/plugin.json
+++ b/plugins/ai-game-studio-macos/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-game-studio-macos",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "An opt-in macOS edition for native Codex AI Game Studio detection, planning, and platform-safe tool adaptation.",
   "author": {
     "name": "frabcd",

--- a/plugins/ai-game-studio-macos/editions/macos.json
+++ b/plugins/ai-game-studio-macos/editions/macos.json
@@ -4,7 +4,7 @@
   "plugin": "ai-game-studio-macos",
   "display_name": "Codex AI Game Studio for macOS",
   "target_os": "Darwin",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "license": "MIT",
   "distribution": "local-codex-marketplace",
   "supported_architectures": [

--- a/plugins/ai-game-studio-macos/scripts/edition.py
+++ b/plugins/ai-game-studio-macos/scripts/edition.py
@@ -11,18 +11,44 @@ from typing import Sequence
 
 
 ALLOWED_COMMANDS = {"doctor", "plan", "apply", "disable", "rollback"}
+EXPECTED_EDITION_ID = "macos"
+EXPECTED_PLUGIN_NAME = "ai-game-studio-macos"
+MAX_DESCRIPTOR_BYTES = 1024 * 1024
 
 
-def load_edition(plugin_root: Path) -> tuple[str, str]:
-    descriptors = sorted((plugin_root / "editions").glob("*.json"))
+def load_edition(plugin_root: Path) -> tuple[str, str, Path]:
+    root = plugin_root.resolve()
+    editions_root = (root / "editions").resolve(strict=True)
+    descriptors = sorted(path for path in editions_root.glob("*.json") if path.is_file())
     if len(descriptors) != 1:
         raise RuntimeError("The edition plugin must contain exactly one descriptor")
-    payload = json.loads(descriptors[0].read_text(encoding="utf-8"))
+    descriptor = descriptors[0].resolve(strict=True)
+    if descriptor.parent != editions_root or descriptor.name != f"{EXPECTED_EDITION_ID}.json":
+        raise RuntimeError("The edition descriptor escapes its plugin or has an unexpected name")
+    if descriptor.stat().st_size > MAX_DESCRIPTOR_BYTES:
+        raise RuntimeError("The edition descriptor is too large")
+    payload = json.loads(descriptor.read_text(encoding="utf-8"))
     edition_id = payload.get("id")
     version = payload.get("version")
-    if not isinstance(edition_id, str) or not isinstance(version, str):
-        raise RuntimeError("The edition descriptor must contain string id and version fields")
-    return edition_id, version
+    if (
+        edition_id != EXPECTED_EDITION_ID
+        or payload.get("plugin") != EXPECTED_PLUGIN_NAME
+        or not isinstance(version, str)
+    ):
+        raise RuntimeError("The edition descriptor does not match this platform plugin")
+    manifest_path = (root / ".codex-plugin" / "plugin.json").resolve(strict=True)
+    try:
+        manifest_path.relative_to(root)
+    except ValueError as exc:
+        raise RuntimeError("The edition plugin manifest escapes its plugin") from exc
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    if (
+        manifest.get("name") != EXPECTED_PLUGIN_NAME
+        or manifest.get("version") != version
+        or manifest.get("license") != "MIT"
+    ):
+        raise RuntimeError("The edition plugin manifest does not match its descriptor")
+    return edition_id, version, descriptor
 
 
 def is_matching_core(candidate: Path, required_version: str) -> bool:
@@ -59,7 +85,11 @@ def find_core_cli(plugin_root: Path, required_version: str) -> Path:
     return matches[-1]
 
 
-def forwarded_arguments(edition_id: str, arguments: Sequence[str]) -> list[str]:
+def forwarded_arguments(
+    edition_id: str,
+    descriptor_path: Path,
+    arguments: Sequence[str],
+) -> list[str]:
     if not arguments or arguments[0] in {"-h", "--help"}:
         return ["edition", "--help"]
     if arguments[0] == "--version":
@@ -71,15 +101,31 @@ def forwarded_arguments(edition_id: str, arguments: Sequence[str]) -> list[str]:
         )
     rest = list(arguments[1:])
     if command in {"doctor", "plan", "disable"}:
-        return ["edition", command, edition_id, *rest]
+        if any(
+            argument == "--descriptor" or argument.startswith("--descriptor=")
+            for argument in rest
+        ):
+            raise RuntimeError("The edition descriptor is fixed by the installed platform plugin")
+        return [
+            "edition",
+            command,
+            edition_id,
+            *rest,
+            "--descriptor",
+            str(descriptor_path),
+        ]
     return ["edition", command, *rest]
 
 
 def main(argv: Sequence[str] | None = None) -> int:
     plugin_root = Path(__file__).resolve().parents[1]
-    edition_id, version = load_edition(plugin_root)
+    edition_id, version, descriptor_path = load_edition(plugin_root)
     core_cli = find_core_cli(plugin_root, version)
-    command = [sys.executable, str(core_cli), *forwarded_arguments(edition_id, argv or sys.argv[1:])]
+    command = [
+        sys.executable,
+        str(core_cli),
+        *forwarded_arguments(edition_id, descriptor_path, argv or sys.argv[1:]),
+    ]
     return subprocess.run(command, check=False).returncode
 
 

--- a/plugins/ai-game-studio-macos/skills/setup-macos-edition/SKILL.md
+++ b/plugins/ai-game-studio-macos/skills/setup-macos-edition/SKILL.md
@@ -5,7 +5,9 @@ description: Inspect a macOS game project and propose one native Apple Silicon o
 
 # Set up the macOS edition
 
-Use the core standard-library Python CLI and the checked-in `macos` edition descriptor. Treat detection, planning, applying, disabling, and rollback as separate phases.
+Use the core standard-library Python CLI and the installed plugin's validated
+`macos` edition descriptor. Treat detection, planning, applying, disabling, and
+rollback as separate phases.
 
 ## Detect without changing the host
 

--- a/plugins/ai-game-studio-pixel/.codex-plugin/plugin.json
+++ b/plugins/ai-game-studio-pixel/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-game-studio-pixel",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "An opt-in, pinned pixel-art MCP adapter and safety workflow for Codex AI Game Studio.",
   "author": {"name": "frabcd", "url": "https://github.com/frabcd"},
   "homepage": "https://frabcd.github.io/codex-ai-game-studio/packs/pixel/",

--- a/plugins/ai-game-studio-unity/.codex-plugin/plugin.json
+++ b/plugins/ai-game-studio-unity/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-game-studio-unity",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "An opt-in, pinned Unity MCP adapter and safety workflow for Codex AI Game Studio.",
   "author": {"name": "frabcd", "url": "https://github.com/frabcd"},
   "homepage": "https://frabcd.github.io/codex-ai-game-studio/packs/unity/",

--- a/plugins/ai-game-studio-unreal/.codex-plugin/plugin.json
+++ b/plugins/ai-game-studio-unreal/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-game-studio-unreal",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "An opt-in, pinned Unreal Engine MCP adapter and safety workflow for Codex AI Game Studio.",
   "author": {"name": "frabcd", "url": "https://github.com/frabcd"},
   "homepage": "https://frabcd.github.io/codex-ai-game-studio/packs/unreal/",

--- a/plugins/ai-game-studio-windows/.codex-plugin/plugin.json
+++ b/plugins/ai-game-studio-windows/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-game-studio-windows",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "A native-first Windows toolchain planner with deterministic cross-platform adaptations for Codex AI Game Studio.",
   "author": {
     "name": "frabcd",

--- a/plugins/ai-game-studio-windows/editions/windows.json
+++ b/plugins/ai-game-studio-windows/editions/windows.json
@@ -4,7 +4,7 @@
   "plugin": "ai-game-studio-windows",
   "display_name": "Codex AI Game Studio for Windows",
   "target_os": "Windows",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "license": "MIT",
   "distribution": "local-codex-marketplace",
   "supported_architectures": [

--- a/plugins/ai-game-studio-windows/scripts/edition.py
+++ b/plugins/ai-game-studio-windows/scripts/edition.py
@@ -11,18 +11,44 @@ from typing import Sequence
 
 
 ALLOWED_COMMANDS = {"doctor", "plan", "apply", "disable", "rollback"}
+EXPECTED_EDITION_ID = "windows"
+EXPECTED_PLUGIN_NAME = "ai-game-studio-windows"
+MAX_DESCRIPTOR_BYTES = 1024 * 1024
 
 
-def load_edition(plugin_root: Path) -> tuple[str, str]:
-    descriptors = sorted((plugin_root / "editions").glob("*.json"))
+def load_edition(plugin_root: Path) -> tuple[str, str, Path]:
+    root = plugin_root.resolve()
+    editions_root = (root / "editions").resolve(strict=True)
+    descriptors = sorted(path for path in editions_root.glob("*.json") if path.is_file())
     if len(descriptors) != 1:
         raise RuntimeError("The edition plugin must contain exactly one descriptor")
-    payload = json.loads(descriptors[0].read_text(encoding="utf-8"))
+    descriptor = descriptors[0].resolve(strict=True)
+    if descriptor.parent != editions_root or descriptor.name != f"{EXPECTED_EDITION_ID}.json":
+        raise RuntimeError("The edition descriptor escapes its plugin or has an unexpected name")
+    if descriptor.stat().st_size > MAX_DESCRIPTOR_BYTES:
+        raise RuntimeError("The edition descriptor is too large")
+    payload = json.loads(descriptor.read_text(encoding="utf-8"))
     edition_id = payload.get("id")
     version = payload.get("version")
-    if not isinstance(edition_id, str) or not isinstance(version, str):
-        raise RuntimeError("The edition descriptor must contain string id and version fields")
-    return edition_id, version
+    if (
+        edition_id != EXPECTED_EDITION_ID
+        or payload.get("plugin") != EXPECTED_PLUGIN_NAME
+        or not isinstance(version, str)
+    ):
+        raise RuntimeError("The edition descriptor does not match this platform plugin")
+    manifest_path = (root / ".codex-plugin" / "plugin.json").resolve(strict=True)
+    try:
+        manifest_path.relative_to(root)
+    except ValueError as exc:
+        raise RuntimeError("The edition plugin manifest escapes its plugin") from exc
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    if (
+        manifest.get("name") != EXPECTED_PLUGIN_NAME
+        or manifest.get("version") != version
+        or manifest.get("license") != "MIT"
+    ):
+        raise RuntimeError("The edition plugin manifest does not match its descriptor")
+    return edition_id, version, descriptor
 
 
 def is_matching_core(candidate: Path, required_version: str) -> bool:
@@ -59,7 +85,11 @@ def find_core_cli(plugin_root: Path, required_version: str) -> Path:
     return matches[-1]
 
 
-def forwarded_arguments(edition_id: str, arguments: Sequence[str]) -> list[str]:
+def forwarded_arguments(
+    edition_id: str,
+    descriptor_path: Path,
+    arguments: Sequence[str],
+) -> list[str]:
     if not arguments or arguments[0] in {"-h", "--help"}:
         return ["edition", "--help"]
     if arguments[0] == "--version":
@@ -71,15 +101,31 @@ def forwarded_arguments(edition_id: str, arguments: Sequence[str]) -> list[str]:
         )
     rest = list(arguments[1:])
     if command in {"doctor", "plan", "disable"}:
-        return ["edition", command, edition_id, *rest]
+        if any(
+            argument == "--descriptor" or argument.startswith("--descriptor=")
+            for argument in rest
+        ):
+            raise RuntimeError("The edition descriptor is fixed by the installed platform plugin")
+        return [
+            "edition",
+            command,
+            edition_id,
+            *rest,
+            "--descriptor",
+            str(descriptor_path),
+        ]
     return ["edition", command, *rest]
 
 
 def main(argv: Sequence[str] | None = None) -> int:
     plugin_root = Path(__file__).resolve().parents[1]
-    edition_id, version = load_edition(plugin_root)
+    edition_id, version, descriptor_path = load_edition(plugin_root)
     core_cli = find_core_cli(plugin_root, version)
-    command = [sys.executable, str(core_cli), *forwarded_arguments(edition_id, argv or sys.argv[1:])]
+    command = [
+        sys.executable,
+        str(core_cli),
+        *forwarded_arguments(edition_id, descriptor_path, argv or sys.argv[1:]),
+    ]
     return subprocess.run(command, check=False).returncode
 
 

--- a/plugins/ai-game-studio/.codex-plugin/plugin.json
+++ b/plugins/ai-game-studio/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-game-studio",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "A safety-first, cross-platform AI game-production studio for Codex with 85 skills and an offline catalog of 163 verified repositories.",
   "author": {
     "name": "frabcd",

--- a/plugins/ai-game-studio/scripts/ags_core.py
+++ b/plugins/ai-game-studio/scripts/ags_core.py
@@ -28,13 +28,36 @@ from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
 
 
-VERSION = "1.1.0"
+VERSION = "1.1.1"
 STATE_DIR = ".ai-game-studio"
 PLAN_TTL_MINUTES = 30
 MAX_SCAN_DEPTH = 5
 MAX_SCAN_FILES = 20_000
 MAX_JSON_BYTES = 16 * 1024 * 1024
 SUPPORTED_OS = {"Windows", "Darwin", "Linux"}
+EDITION_CONTRACT = {
+    "windows": {
+        "plugin": "ai-game-studio-windows",
+        "target_os": "Windows",
+    },
+    "macos": {
+        "plugin": "ai-game-studio-macos",
+        "target_os": "Darwin",
+    },
+}
+EDITION_REQUIRED_LISTS = (
+    "supported_architectures",
+    "shells",
+    "package_managers",
+    "gpu_backends",
+    "applications",
+    "native_capabilities",
+    "adaptation_rules",
+    "permissions",
+    "health_checks",
+    "uninstall",
+    "rollback",
+)
 KNOWN_CREDENTIALS = (
     "GITHUB_TOKEN",
     "GH_TOKEN",
@@ -670,6 +693,132 @@ def load_edition_descriptors() -> dict[str, dict[str, Any]]:
     return result
 
 
+def load_supplied_edition_descriptor(
+    edition_id: str,
+    descriptor_path: Path,
+) -> dict[str, Any]:
+    """Load a descriptor supplied by an independently cached edition plugin.
+
+    The descriptor remains read-only at its installed path. It is accepted only
+    from a complete, version-matched edition plugin and its declarative fields
+    are validated before they can influence a doctor report or transaction.
+    """
+
+    contract = EDITION_CONTRACT.get(edition_id)
+    if contract is None:
+        raise StudioError(f"Unknown edition '{edition_id}'")
+    if not descriptor_path.is_absolute():
+        raise StudioError("Supplied edition descriptor path must be absolute")
+    try:
+        resolved = descriptor_path.resolve(strict=True)
+    except (OSError, RuntimeError) as exc:
+        raise StudioError(f"Supplied edition descriptor is unavailable: {descriptor_path}") from exc
+    if resolved.name != f"{edition_id}.json" or resolved.parent.name != "editions":
+        raise StudioError(
+            f"Supplied {edition_id} descriptor must be named editions/{edition_id}.json"
+        )
+
+    plugin_dir = resolved.parent.parent
+    try:
+        editions_dir = (plugin_dir / "editions").resolve(strict=True)
+    except (OSError, RuntimeError) as exc:
+        raise StudioError("Supplied edition descriptor directory is unavailable") from exc
+    if resolved.parent != editions_dir:
+        raise StudioError("Supplied edition descriptor escapes its plugin editions directory")
+
+    manifest_path = plugin_dir / ".codex-plugin" / "plugin.json"
+    try:
+        resolved_manifest = manifest_path.resolve(strict=True)
+        resolved_manifest.relative_to(plugin_dir)
+    except (OSError, RuntimeError, ValueError) as exc:
+        raise StudioError("Supplied edition descriptor has no bounded plugin manifest") from exc
+    manifest = safe_json_load(resolved_manifest)
+    expected_plugin = str(contract["plugin"])
+    if not isinstance(manifest, dict):
+        raise StudioError("Supplied edition descriptor has no valid plugin manifest")
+    if (
+        manifest.get("name") != expected_plugin
+        or manifest.get("version") != VERSION
+        or manifest.get("license") != "MIT"
+    ):
+        raise StudioError(
+            f"Supplied edition plugin must be {expected_plugin} {VERSION} under the MIT license"
+        )
+
+    descriptor = safe_json_load(resolved)
+    if not isinstance(descriptor, dict):
+        raise StudioError("Supplied edition descriptor must contain a JSON object")
+    expected_fields = {
+        "id": edition_id,
+        "plugin": expected_plugin,
+        "target_os": str(contract["target_os"]),
+        "version": VERSION,
+        "license": "MIT",
+    }
+    for field, expected in expected_fields.items():
+        if descriptor.get(field) != expected:
+            raise StudioError(
+                f"Supplied edition descriptor field {field!r} must be {expected!r}"
+            )
+    for field in EDITION_REQUIRED_LISTS:
+        value = descriptor.get(field)
+        if not isinstance(value, list) or not value:
+            raise StudioError(
+                f"Supplied edition descriptor field {field!r} must be a non-empty array"
+            )
+    required_rule_fields = {
+        "id",
+        "source_constraint",
+        "preferred_native",
+        "alternatives",
+        "limitations",
+        "requires_confirmation",
+    }
+    for rule in descriptor["adaptation_rules"]:
+        if (
+            not isinstance(rule, dict)
+            or required_rule_fields - set(rule)
+            or not isinstance(rule.get("id"), str)
+            or not rule.get("id")
+            or not isinstance(rule.get("source_constraint"), str)
+            or not rule.get("source_constraint")
+            or not isinstance(rule.get("preferred_native"), str)
+            or not rule.get("preferred_native")
+            or not isinstance(rule.get("alternatives"), list)
+            or not rule.get("alternatives")
+            or rule.get("requires_confirmation") is not True
+            or not rule.get("limitations")
+        ):
+            raise StudioError(
+                "Supplied edition adaptation rules must disclose limitations and require confirmation"
+            )
+    activation = descriptor.get("activation")
+    if (
+        not isinstance(activation, dict)
+        or activation.get("mode") != "confirmed-transaction-only"
+        or activation.get("project_state") != f"{STATE_DIR}/project.json"
+        or activation.get("lock_file") != f"{STATE_DIR}/lock.json"
+    ):
+        raise StudioError("Supplied edition descriptor has an unsafe activation scope")
+
+    descriptor["_descriptor_path"] = str(resolved)
+    return descriptor
+
+
+def select_edition_descriptor(
+    edition_id: str,
+    supplied_path: Path | None = None,
+) -> dict[str, Any]:
+    if supplied_path is not None:
+        return load_supplied_edition_descriptor(edition_id, supplied_path)
+    descriptors = load_edition_descriptors()
+    if edition_id not in descriptors:
+        raise StudioError(
+            f"Unknown edition '{edition_id}'. Available: {', '.join(sorted(descriptors)) or 'none'}"
+        )
+    return descriptors[edition_id]
+
+
 def edition_host_detection(edition_id: str, environment: Mapping[str, Any]) -> dict[str, Any]:
     """Run fixed, read-only probes for the selected platform descriptor.
 
@@ -810,13 +959,13 @@ def write_action(target: str, value: Any) -> dict[str, Any]:
     return {"operation": "write-file", "target": target, "content_base64": encode_action_json(value)}
 
 
-def edition_doctor(edition_id: str, *, project_root: Path) -> dict[str, Any]:
-    descriptors = load_edition_descriptors()
-    if edition_id not in descriptors:
-        raise StudioError(
-            f"Unknown edition '{edition_id}'. Available: {', '.join(sorted(descriptors)) or 'none'}"
-        )
-    descriptor = descriptors[edition_id]
+def edition_doctor(
+    edition_id: str,
+    *,
+    project_root: Path,
+    descriptor_path: Path | None = None,
+) -> dict[str, Any]:
+    descriptor = select_edition_descriptor(edition_id, descriptor_path)
     environment = doctor(project_root)
     environment["edition_detection"] = edition_host_detection(edition_id, environment)
     detected_platform = environment.get("platform") if isinstance(environment, dict) else {}
@@ -841,13 +990,13 @@ def edition_doctor(edition_id: str, *, project_root: Path) -> dict[str, Any]:
     }
 
 
-def edition_plan(edition_id: str, *, project_root: Path) -> dict[str, Any]:
-    descriptors = load_edition_descriptors()
-    if edition_id not in descriptors:
-        raise StudioError(
-            f"Unknown edition '{edition_id}'. Available: {', '.join(sorted(descriptors)) or 'none'}"
-        )
-    descriptor = descriptors[edition_id]
+def edition_plan(
+    edition_id: str,
+    *,
+    project_root: Path,
+    descriptor_path: Path | None = None,
+) -> dict[str, Any]:
+    descriptor = select_edition_descriptor(edition_id, descriptor_path)
     system = platform.system()
     machine = platform.machine().lower()
     target_os = str(descriptor.get("target_os", ""))
@@ -913,10 +1062,13 @@ def edition_plan(edition_id: str, *, project_root: Path) -> dict[str, Any]:
     )
 
 
-def edition_disable_plan(edition_id: str, *, project_root: Path) -> dict[str, Any]:
-    descriptors = load_edition_descriptors()
-    if edition_id not in descriptors:
-        raise StudioError(f"Unknown edition '{edition_id}'")
+def edition_disable_plan(
+    edition_id: str,
+    *,
+    project_root: Path,
+    descriptor_path: Path | None = None,
+) -> dict[str, Any]:
+    select_edition_descriptor(edition_id, descriptor_path)
     project, lock = state_documents(project_root)
     selected = project.get("platform_edition")
     if not isinstance(selected, dict) or selected.get("id") != edition_id:
@@ -1647,10 +1799,20 @@ def build_parser() -> argparse.ArgumentParser:
     edition_doctor_parser = edition.add_parser("doctor")
     edition_doctor_parser.add_argument("edition_id", choices=("windows", "macos"))
     add_project_argument(edition_doctor_parser)
+    edition_doctor_parser.add_argument(
+        "--descriptor",
+        type=Path,
+        help=argparse.SUPPRESS,
+    )
     edition_plan_parser = edition.add_parser("plan")
     edition_plan_parser.add_argument("edition_id", choices=("windows", "macos"))
     add_project_argument(edition_plan_parser)
     edition_plan_parser.add_argument("--output")
+    edition_plan_parser.add_argument(
+        "--descriptor",
+        type=Path,
+        help=argparse.SUPPRESS,
+    )
     edition_apply_parser = edition.add_parser("apply")
     edition_apply_parser.add_argument("--plan", required=True)
     edition_apply_parser.add_argument("--confirmed-digest", required=True)
@@ -1659,6 +1821,11 @@ def build_parser() -> argparse.ArgumentParser:
     edition_disable_parser.add_argument("edition_id", choices=("windows", "macos"))
     add_project_argument(edition_disable_parser)
     edition_disable_parser.add_argument("--output")
+    edition_disable_parser.add_argument(
+        "--descriptor",
+        type=Path,
+        help=argparse.SUPPRESS,
+    )
     edition_rollback_parser = edition.add_parser("rollback")
     edition_rollback_parser.add_argument("transaction_id")
     add_project_argument(edition_rollback_parser)
@@ -1715,9 +1882,22 @@ def main(argv: Sequence[str] | None = None) -> int:
         elif args.command == "edition":
             root = Path(args.project)
             if args.edition_command == "doctor":
-                emit(edition_doctor(args.edition_id, project_root=root))
+                emit(
+                    edition_doctor(
+                        args.edition_id,
+                        project_root=root,
+                        descriptor_path=args.descriptor,
+                    )
+                )
             elif args.edition_command == "plan":
-                maybe_write_plan(edition_plan(args.edition_id, project_root=root), args.output)
+                maybe_write_plan(
+                    edition_plan(
+                        args.edition_id,
+                        project_root=root,
+                        descriptor_path=args.descriptor,
+                    ),
+                    args.output,
+                )
             elif args.edition_command == "apply":
                 plan = safe_json_load(Path(args.plan).expanduser().resolve())
                 if not isinstance(plan, dict):
@@ -1725,7 +1905,14 @@ def main(argv: Sequence[str] | None = None) -> int:
                 validate_edition_apply_plan(plan)
                 emit(apply_plan(plan, project_root=root, confirmed_digest=args.confirmed_digest))
             elif args.edition_command == "disable":
-                maybe_write_plan(edition_disable_plan(args.edition_id, project_root=root), args.output)
+                maybe_write_plan(
+                    edition_disable_plan(
+                        args.edition_id,
+                        project_root=root,
+                        descriptor_path=args.descriptor,
+                    ),
+                    args.output,
+                )
             else:
                 maybe_write_plan(
                     rollback_plan(

--- a/release/README.md
+++ b/release/README.md
@@ -3,7 +3,7 @@
 Release archives are generated, not edited by hand:
 
 ```text
-python tools/build_release.py --version 1.1.0 --output dist
+python tools/build_release.py --version 1.1.1 --output dist
 ```
 
 The builder creates one complete marketplace ZIP, ten standalone plugin ZIPs,
@@ -12,6 +12,11 @@ machine-readable release manifest, and `SHA256SUMS`. Every ZIP uses sorted
 paths, fixed file metadata, explicit text line endings, and the DOS epoch
 timestamp so identical source trees produce identical bytes across Windows,
 macOS, and Linux.
+
+The requested archive version must match every checked-in plugin manifest and
+platform descriptor. Existing GitHub releases are immutable: a rerun for a
+published tag stops before validation, build, attestation, or upload and never
+replaces assets.
 
 GitHub's release workflow validates the repository, rebuilds the artifacts, and
 adds a GitHub build-provenance attestation. A release must be triggered from an

--- a/tests/test_cli_runtime.py
+++ b/tests/test_cli_runtime.py
@@ -20,7 +20,7 @@ class CliSurfaceTests(unittest.TestCase):
     def test_version(self) -> None:
         result = self.run_cli("--version")
         self.assertEqual(result.returncode, 0, result.stderr)
-        self.assertEqual(result.stdout.strip(), "1.1.0")
+        self.assertEqual(result.stdout.strip(), "1.1.1")
 
     def test_native_launcher_for_current_platform(self) -> None:
         scripts = CLI.parent
@@ -32,7 +32,7 @@ class CliSurfaceTests(unittest.TestCase):
             command = ["/bin/sh", str(scripts / "ai-game-studio.sh"), "--version"]
         result = subprocess.run(command, cwd=REPO, capture_output=True, text=True, check=False, timeout=30)
         self.assertEqual(result.returncode, 0, result.stderr)
-        self.assertEqual(result.stdout.strip(), "1.1.0")
+        self.assertEqual(result.stdout.strip(), "1.1.1")
 
     def test_required_command_surface(self) -> None:
         root_help = self.run_cli("--help")

--- a/tests/test_edition_launchers.py
+++ b/tests/test_edition_launchers.py
@@ -2,9 +2,12 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import os
 from pathlib import Path
 import platform
+import shutil
 import subprocess
+import sys
 import tempfile
 import unittest
 
@@ -28,7 +31,7 @@ def load_launcher(edition: str):
     return module
 
 
-def make_fake_core(plugin_root: Path, version: str = "1.1.0") -> Path:
+def make_fake_core(plugin_root: Path, version: str = "1.1.1") -> Path:
     cli = plugin_root / "scripts" / "ai_game_studio.py"
     cli.parent.mkdir(parents=True)
     cli.write_text("print('fake core')\n", encoding="utf-8")
@@ -41,23 +44,78 @@ def make_fake_core(plugin_root: Path, version: str = "1.1.0") -> Path:
     return cli.resolve()
 
 
+def copy_runtime_file(source_root: Path, destination_root: Path, relative: str) -> Path:
+    destination = destination_root / relative
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(source_root / relative, destination)
+    return destination
+
+
+def make_installed_core(plugin_root: Path) -> Path:
+    source = ROOT / "plugins" / "ai-game-studio"
+    copy_runtime_file(source, plugin_root, ".codex-plugin/plugin.json")
+    copy_runtime_file(source, plugin_root, "scripts/ags_core.py")
+    return copy_runtime_file(
+        source,
+        plugin_root,
+        "scripts/ai_game_studio.py",
+    ).resolve()
+
+
+def make_installed_edition(plugin_root: Path, edition: str) -> Path:
+    source = ROOT / "plugins" / f"ai-game-studio-{edition}"
+    copy_runtime_file(source, plugin_root, ".codex-plugin/plugin.json")
+    copy_runtime_file(source, plugin_root, f"editions/{edition}.json")
+    return copy_runtime_file(source, plugin_root, "scripts/edition.py").resolve()
+
+
 class EditionLauncherTests(unittest.TestCase):
     def test_arguments_are_namespaced_without_command_strings(self) -> None:
         for edition in ("windows", "macos"):
             launcher = load_launcher(edition)
+            descriptor = (
+                ROOT
+                / "plugins"
+                / f"ai-game-studio-{edition}"
+                / "editions"
+                / f"{edition}.json"
+            ).resolve()
             self.assertEqual(
-                launcher.forwarded_arguments(edition, ["doctor", "--project", "game"]),
-                ["edition", "doctor", edition, "--project", "game"],
+                launcher.forwarded_arguments(
+                    edition,
+                    descriptor,
+                    ["doctor", "--project", "game"],
+                ),
+                [
+                    "edition",
+                    "doctor",
+                    edition,
+                    "--project",
+                    "game",
+                    "--descriptor",
+                    str(descriptor),
+                ],
             )
             self.assertEqual(
                 launcher.forwarded_arguments(
                     edition,
+                    descriptor,
                     ["apply", "--project", "game", "--plan", "plan.json"],
                 ),
                 ["edition", "apply", "--project", "game", "--plan", "plan.json"],
             )
             with self.assertRaises(RuntimeError):
-                launcher.forwarded_arguments(edition, ["install-everything"])
+                launcher.forwarded_arguments(
+                    edition,
+                    descriptor,
+                    ["install-everything"],
+                )
+            with self.assertRaisesRegex(RuntimeError, "fixed by the installed"):
+                launcher.forwarded_arguments(
+                    edition,
+                    descriptor,
+                    ["doctor", "--descriptor", "untrusted.json"],
+                )
 
     def test_core_is_found_in_repository_and_marketplace_cache_layouts(self) -> None:
         launcher = load_launcher("windows")
@@ -68,7 +126,7 @@ class EditionLauncherTests(unittest.TestCase):
             repository_platform.mkdir(parents=True)
             direct_core = make_fake_core(repository_plugins / "ai-game-studio")
             self.assertEqual(
-                launcher.find_core_cli(repository_platform, "1.1.0"), direct_core
+                launcher.find_core_cli(repository_platform, "1.1.1"), direct_core
             )
 
             marketplace = root / "cache" / "frabcd-ai-game-studio"
@@ -80,10 +138,63 @@ class EditionLauncherTests(unittest.TestCase):
                 marketplace / "ai-game-studio" / "source-snapshot"
             )
             self.assertEqual(
-                launcher.find_core_cli(cached_platform, "1.1.0"), cached_core
+                launcher.find_core_cli(cached_platform, "1.1.1"), cached_core
             )
             with self.assertRaises(RuntimeError):
                 launcher.find_core_cli(cached_platform, "9.9.9")
+
+    def test_clean_marketplace_cache_wrapper_runs_real_edition_doctor(self) -> None:
+        edition = {
+            "Windows": "windows",
+            "Darwin": "macos",
+        }.get(platform.system())
+        if edition is None:
+            self.skipTest("real platform wrapper smoke runs on Windows and macOS")
+
+        with tempfile.TemporaryDirectory(prefix="ags-clean-marketplace-") as temporary:
+            root = Path(temporary)
+            marketplace = root / "cache" / "frabcd-ai-game-studio"
+            core_root = marketplace / "ai-game-studio" / "core-snapshot"
+            platform_root = (
+                marketplace
+                / f"ai-game-studio-{edition}"
+                / "edition-snapshot"
+            )
+            make_installed_core(core_root)
+            launcher = make_installed_edition(platform_root, edition)
+            descriptor = platform_root / "editions" / f"{edition}.json"
+            descriptor_before = descriptor.read_bytes()
+            project = root / "game"
+            project.mkdir()
+            environment = os.environ.copy()
+            environment["PYTHONDONTWRITEBYTECODE"] = "1"
+
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(launcher),
+                    "doctor",
+                    "--project",
+                    str(project),
+                ],
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                env=environment,
+                timeout=60,
+                check=False,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            report = json.loads(result.stdout)
+            self.assertEqual(report["edition"], edition)
+            self.assertTrue(report["read_only"])
+            self.assertTrue(report["target_matches_host"])
+            self.assertFalse(report["mutation_performed"])
+            self.assertNotIn("Available: none", result.stderr)
+            self.assertFalse((project / ".ai-game-studio").exists())
+            self.assertEqual(descriptor.read_bytes(), descriptor_before)
+            self.assertFalse((core_root / "editions").exists())
 
     def test_native_launcher_reaches_checked_in_core(self) -> None:
         system = platform.system()
@@ -123,7 +234,7 @@ class EditionLauncherTests(unittest.TestCase):
             check=False,
         )
         self.assertEqual(result.returncode, 0, result.stderr)
-        self.assertIn("1.1.0", result.stdout)
+        self.assertIn("1.1.1", result.stdout)
 
 
 if __name__ == "__main__":

--- a/tests/test_edition_runtime.py
+++ b/tests/test_edition_runtime.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import shutil
 import sys
 import tempfile
 import unittest
@@ -41,13 +42,66 @@ class EditionRuntimeTests(unittest.TestCase):
         self.assertEqual(set(descriptors), {"windows", "macos"})
         for edition_id, descriptor in descriptors.items():
             self.assertEqual(descriptor["id"], edition_id)
-            self.assertEqual(descriptor["version"], "1.1.0")
+            self.assertEqual(descriptor["version"], "1.1.1")
             self.assertEqual(descriptor["license"], "MIT")
             self.assertEqual(descriptor["activation"]["mode"], "confirmed-transaction-only")
             self.assertTrue(descriptor["adaptation_rules"])
             for rule in descriptor["adaptation_rules"]:
                 self.assertTrue(rule["requires_confirmation"])
                 self.assertTrue(rule["limitations"])
+
+    def test_supplied_descriptor_requires_a_matching_complete_plugin(self) -> None:
+        source = REPO / "plugins" / "ai-game-studio-windows"
+        installed = self.project / "cache" / "ai-game-studio-windows" / "snapshot"
+        descriptor = installed / "editions" / "windows.json"
+        descriptor.parent.mkdir(parents=True)
+        shutil.copy2(source / "editions" / "windows.json", descriptor)
+
+        with self.assertRaisesRegex(core.StudioError, "no bounded plugin manifest"):
+            core.edition_doctor(
+                "windows",
+                project_root=self.project,
+                descriptor_path=descriptor.resolve(),
+            )
+
+        manifest = installed / ".codex-plugin" / "plugin.json"
+        manifest.parent.mkdir(parents=True)
+        shutil.copy2(source / ".codex-plugin" / "plugin.json", manifest)
+        report = core.edition_doctor(
+            "windows",
+            project_root=self.project,
+            descriptor_path=descriptor.resolve(),
+        )
+        self.assertEqual(report["edition"], "windows")
+        self.assertTrue(report["read_only"])
+        self.assertFalse((self.project / core.STATE_DIR).exists())
+        with mock.patch.object(core.platform, "system", return_value="Windows"), mock.patch.object(
+            core.platform, "machine", return_value="AMD64"
+        ):
+            plan = core.edition_plan(
+                "windows",
+                project_root=self.project,
+                descriptor_path=descriptor.resolve(),
+            )
+        self.assertEqual(plan["metadata"]["edition"], "windows")
+        self.assertEqual(
+            plan["metadata"]["descriptor_sha256"],
+            core.file_sha256(descriptor),
+        )
+        self.assertFalse((self.project / core.STATE_DIR).exists())
+
+        with self.assertRaisesRegex(core.StudioError, "must be absolute"):
+            core.edition_doctor(
+                "windows",
+                project_root=self.project,
+                descriptor_path=Path("editions/windows.json"),
+            )
+        with self.assertRaisesRegex(core.StudioError, "must be named"):
+            core.edition_doctor(
+                "macos",
+                project_root=self.project,
+                descriptor_path=descriptor.resolve(),
+            )
 
     def test_edition_doctor_is_read_only_and_exposes_adaptations(self) -> None:
         report = core.edition_doctor("windows", project_root=self.project)

--- a/tests/test_img2threejs_runtime_portability.py
+++ b/tests/test_img2threejs_runtime_portability.py
@@ -88,6 +88,8 @@ class SpecSearchCachePortabilityTests(unittest.TestCase):
         script = FORGE_ROOT / "stage1_intake" / "search_specs.py"
         with tempfile.TemporaryDirectory() as temporary:
             cache_root = Path(temporary) / "search-cache"
+            environment = os.environ.copy()
+            environment["PYTHONDONTWRITEBYTECODE"] = "1"
             result = subprocess.run(
                 [
                     sys.executable,
@@ -103,6 +105,7 @@ class SpecSearchCachePortabilityTests(unittest.TestCase):
                 capture_output=True,
                 text=True,
                 encoding="utf-8",
+                env=environment,
                 check=False,
                 timeout=60,
             )

--- a/tests/test_macos_edition.py
+++ b/tests/test_macos_edition.py
@@ -16,7 +16,7 @@ class MacOSEditionTests(unittest.TestCase):
             (PLUGIN / ".codex-plugin" / "plugin.json").read_text(encoding="utf-8")
         )
         self.assertEqual(manifest["name"], "ai-game-studio-macos")
-        self.assertEqual(manifest["version"], "1.1.0")
+        self.assertEqual(manifest["version"], "1.1.1")
         self.assertEqual(manifest["license"], "MIT")
         self.assertLessEqual(len(manifest["interface"]["defaultPrompt"]), 128)
 
@@ -62,7 +62,7 @@ class MacOSEditionTests(unittest.TestCase):
         self.assertEqual(descriptor["id"], "macos")
         self.assertEqual(descriptor["plugin"], "ai-game-studio-macos")
         self.assertEqual(descriptor["target_os"], "Darwin")
-        self.assertEqual(descriptor["version"], "1.1.0")
+        self.assertEqual(descriptor["version"], "1.1.1")
         self.assertEqual(descriptor["license"], "MIT")
         self.assertEqual(
             set(descriptor["supported_architectures"]), {"arm64", "x86_64"}

--- a/tests/test_release_builder.py
+++ b/tests/test_release_builder.py
@@ -18,6 +18,16 @@ def digest(path: Path) -> str:
 
 
 class ReleaseBuilderTests(unittest.TestCase):
+    def test_release_version_must_match_checked_in_packages(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="ags-release-version-") as temporary:
+            output = Path(temporary) / "dist"
+            with self.assertRaisesRegex(
+                ValueError,
+                "does not match checked-in package versions",
+            ):
+                build_release.build(ROOT, output, "9.9.9")
+            self.assertFalse(output.exists())
+
     def test_source_payloads_have_checkout_independent_line_endings(self) -> None:
         with tempfile.TemporaryDirectory(prefix="ags-release-lines-") as temporary:
             root = Path(temporary)
@@ -39,8 +49,8 @@ class ReleaseBuilderTests(unittest.TestCase):
             prefix="ags-release-b-"
         ) as second:
             first_dir, second_dir = Path(first), Path(second)
-            build_release.build(ROOT, first_dir, "1.1.0")
-            build_release.build(ROOT, second_dir, "1.1.0")
+            build_release.build(ROOT, first_dir, "1.1.1")
+            build_release.build(ROOT, second_dir, "1.1.1")
             first_files = sorted(path.name for path in first_dir.iterdir())
             second_files = sorted(path.name for path in second_dir.iterdir())
             self.assertEqual(first_files, second_files)
@@ -49,10 +59,10 @@ class ReleaseBuilderTests(unittest.TestCase):
                 self.assertEqual(digest(first_dir / name), digest(second_dir / name), name)
 
             manifest = json.loads((first_dir / "release-manifest.json").read_text(encoding="utf-8"))
-            self.assertEqual("1.1.0", manifest["version"])
+            self.assertEqual("1.1.1", manifest["version"])
             self.assertEqual({"macos", "windows"}, set(manifest["editions"]))
             self.assertEqual(14, len(manifest["artifacts"]))
-            sbom = json.loads((first_dir / "codex-ai-game-studio-v1.1.0.spdx.json").read_text(encoding="utf-8"))
+            sbom = json.loads((first_dir / "codex-ai-game-studio-v1.1.1.spdx.json").read_text(encoding="utf-8"))
             self.assertEqual("SPDX-2.3", sbom["spdxVersion"])
             self.assertEqual("MIT AND Apache-2.0", sbom["packages"][0]["licenseDeclared"])
             self.assertGreater(len(sbom["files"]), 100)
@@ -60,7 +70,7 @@ class ReleaseBuilderTests(unittest.TestCase):
     def test_archives_use_safe_sorted_paths_and_fixed_timestamps(self) -> None:
         with tempfile.TemporaryDirectory(prefix="ags-release-zip-") as temporary:
             output = Path(temporary)
-            build_release.build(ROOT, output, "1.1.0")
+            build_release.build(ROOT, output, "1.1.1")
             for archive_path in output.glob("*.zip"):
                 with zipfile.ZipFile(archive_path) as archive:
                     names = archive.namelist()
@@ -84,8 +94,8 @@ class ReleaseBuilderTests(unittest.TestCase):
             selected = build_release.release_files(ROOT, output=Path(output).resolve())
             self.assertNotIn(ignored_sentinel, selected)
             self.assertNotIn(output_sentinel, selected)
-            build_release.build(ROOT, Path(output), "1.1.0")
-            with zipfile.ZipFile(Path(output) / "codex-ai-game-studio-v1.1.0.zip") as archive:
+            build_release.build(ROOT, Path(output), "1.1.1")
+            with zipfile.ZipFile(Path(output) / "codex-ai-game-studio-v1.1.1.zip") as archive:
                 names = archive.namelist()
                 self.assertFalse(any("must-not-ship.txt" in name for name in names))
                 self.assertFalse(any("must-not-recurse.txt" in name for name in names))
@@ -93,7 +103,7 @@ class ReleaseBuilderTests(unittest.TestCase):
     def test_platform_editions_contain_only_the_matching_platform_plugin(self) -> None:
         with tempfile.TemporaryDirectory(prefix="ags-editions-") as temporary:
             output = Path(temporary)
-            build_release.build(ROOT, output, "1.1.0")
+            build_release.build(ROOT, output, "1.1.1")
             required_img_references = {
                 "cs2_finishes.md",
                 "geometry_patterns.md",
@@ -103,8 +113,8 @@ class ReleaseBuilderTests(unittest.TestCase):
                 ("windows", "ai-game-studio-windows", "ai-game-studio-macos"),
                 ("macos", "ai-game-studio-macos", "ai-game-studio-windows"),
             ):
-                archive_path = output / f"codex-ai-game-studio-{edition}-v1.1.0.zip"
-                prefix = f"codex-ai-game-studio-{edition}-v1.1.0"
+                archive_path = output / f"codex-ai-game-studio-{edition}-v1.1.1.zip"
+                prefix = f"codex-ai-game-studio-{edition}-v1.1.1"
                 with zipfile.ZipFile(archive_path) as archive:
                     names = archive.namelist()
                     self.assertIn(f"{prefix}/README.md", names)
@@ -142,12 +152,12 @@ class ReleaseBuilderTests(unittest.TestCase):
 
             for archive_name, prefix in (
                 (
-                    "ai-game-studio-img2threejs-v1.1.0.zip",
+                    "ai-game-studio-img2threejs-v1.1.1.zip",
                     "ai-game-studio-img2threejs",
                 ),
                 (
-                    "codex-ai-game-studio-v1.1.0.zip",
-                    "codex-ai-game-studio-v1.1.0/plugins/ai-game-studio-img2threejs",
+                    "codex-ai-game-studio-v1.1.1.zip",
+                    "codex-ai-game-studio-v1.1.1/plugins/ai-game-studio-img2threejs",
                 ),
             ):
                 with zipfile.ZipFile(output / archive_name) as archive:

--- a/tests/test_repository_security.py
+++ b/tests/test_repository_security.py
@@ -49,6 +49,22 @@ class RepositorySecurityTests(unittest.TestCase):
             messages = [problem.render() for problem in validator.problems]
             self.assertTrue(any("workflow-unpinned" in message for message in messages))
 
+    def test_workflow_scan_rejects_release_asset_replacement(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="ags-release-workflow-") as temporary:
+            root = Path(temporary)
+            workflows = root / ".github" / "workflows"
+            workflows.mkdir(parents=True)
+            (workflows / "release.yml").write_text(
+                "steps:\n"
+                "  - run: gh release upload \"$RELEASE_TAG\" dist/* --clobber\n",
+                encoding="utf-8",
+            )
+            validator = Validator(root)
+            validator.validate_workflows()
+            codes = {problem.code for problem in validator.problems}
+            self.assertIn("release-mutable-assets", codes)
+            self.assertIn("release-immutability-guard", codes)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_windows_edition.py
+++ b/tests/test_windows_edition.py
@@ -16,7 +16,7 @@ class WindowsEditionTests(unittest.TestCase):
             (PLUGIN / ".codex-plugin" / "plugin.json").read_text(encoding="utf-8")
         )
         self.assertEqual(manifest["name"], "ai-game-studio-windows")
-        self.assertEqual(manifest["version"], "1.1.0")
+        self.assertEqual(manifest["version"], "1.1.1")
         self.assertEqual(manifest["license"], "MIT")
         self.assertLessEqual(len(manifest["interface"]["defaultPrompt"]), 128)
 
@@ -64,7 +64,7 @@ class WindowsEditionTests(unittest.TestCase):
         self.assertEqual(descriptor["id"], "windows")
         self.assertEqual(descriptor["plugin"], "ai-game-studio-windows")
         self.assertEqual(descriptor["target_os"], "Windows")
-        self.assertEqual(descriptor["version"], "1.1.0")
+        self.assertEqual(descriptor["version"], "1.1.1")
         self.assertEqual(descriptor["license"], "MIT")
         self.assertEqual(
             set(descriptor["supported_architectures"]), {"amd64", "arm64"}

--- a/tools/build_release.py
+++ b/tools/build_release.py
@@ -102,6 +102,34 @@ def canonical_file_bytes(path: Path) -> bytes:
     return normalized.encode("utf-8")
 
 
+def validate_release_version(root: Path, version: str) -> None:
+    """Require archive labels to match every shipped plugin and edition version."""
+
+    versioned_paths = [
+        root / "plugins" / plugin_name / ".codex-plugin" / "plugin.json"
+        for plugin_name in PLUGIN_NAMES
+    ]
+    versioned_paths.extend(
+        root / "plugins" / f"ai-game-studio-{edition}" / "editions" / f"{edition}.json"
+        for edition in sorted(EDITION_PLUGINS)
+    )
+    mismatches: list[str] = []
+    for path in versioned_paths:
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            raise ValueError(f"cannot read release version from {path}: {exc}") from exc
+        actual = payload.get("version") if isinstance(payload, dict) else None
+        if actual != version:
+            relative = path.relative_to(root).as_posix()
+            mismatches.append(f"{relative}={actual!r}")
+    if mismatches:
+        raise ValueError(
+            f"release version {version!r} does not match checked-in package versions: "
+            + ", ".join(mismatches)
+        )
+
+
 def release_files(root: Path, *, output: Path | None = None) -> list[Path]:
     files: list[Path] = []
     for path in root.rglob("*"):
@@ -339,6 +367,7 @@ def build(root: Path, output: Path, version: str) -> dict[str, object]:
     output = output.resolve()
     if output == root or root in output.parents and output.name in {".git", "plugins"}:
         raise ValueError("release output must not overwrite repository inputs")
+    validate_release_version(root, version)
     output.mkdir(parents=True, exist_ok=True)
 
     full_files = release_files(root, output=output)
@@ -406,7 +435,7 @@ def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--root", type=Path, default=Path(__file__).resolve().parents[1])
     parser.add_argument("--output", type=Path, default=Path("dist"))
-    parser.add_argument("--version", default="1.1.0")
+    parser.add_argument("--version", default="1.1.1")
     args = parser.parse_args()
     if not re_semver(args.version):
         parser.error("--version must be a strict semantic version")

--- a/tools/validate_repository.py
+++ b/tools/validate_repository.py
@@ -124,7 +124,7 @@ EXPECTED_HOOK_EVENTS = frozenset(
 
 PINNED_UPSTREAM_COMMIT = "984023ddac0d5e27624f2baacde6105e45de375f"
 PINNED_IMG2THREEJS_COMMIT = "9a8ecf129a58c1b557a1f03f7727f6295672cd51"
-RELEASE_VERSION = "1.1.0"
+RELEASE_VERSION = "1.1.1"
 HEX_SHA = re.compile(r"^[0-9a-f]{40}$")
 SEMVER = re.compile(r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:[-+][0-9A-Za-z.-]+)?$")
 ACTION_USE = re.compile(r"^\s*-?\s*uses:\s*([^\s#]+)", re.MULTILINE)
@@ -883,6 +883,27 @@ class Validator:
                 revision = use.rsplit("@", 1)[1]
                 if not HEX_SHA.fullmatch(revision):
                     self.error("workflow-unpinned", path, f"action must use a 40-character commit SHA: {use}")
+            if path.name == "release.yml":
+                forbidden = ("gh release upload", "--clobber")
+                if any(token in text for token in forbidden):
+                    self.error(
+                        "release-mutable-assets",
+                        path,
+                        "release workflow must never replace assets for an existing tag",
+                    )
+                required = (
+                    "group: release-${{ inputs.version || github.ref_name }}",
+                    "gh release view \"$RELEASE_TAG\"",
+                    "refusing to replace immutable assets",
+                    "gh release create \"$RELEASE_TAG\"",
+                )
+                missing = [token for token in required if token not in text]
+                if missing:
+                    self.error(
+                        "release-immutability-guard",
+                        path,
+                        f"release workflow is missing immutable publication guards: {missing}",
+                    )
 
     def validate_source_safety(self) -> None:
         ignored_parts = {".git", ".official", "dist", "sources", "__pycache__"}


### PR DESCRIPTION
## Summary

- fix Windows and macOS edition launchers when Codex installs platform and core plugins in independent marketplace cache directories
- securely hand the platform plugin's canonical, read-only descriptor to an exact-version core
- bump all marketplace packages and edition descriptors to v1.1.1
- bind release archive labels to checked-in package versions and make GitHub release assets immutable
- document that v1.1.0 is affected and add upgrade guidance

## Safety

The core accepts only an absolute `editions/<platform>.json` inside the matching MIT platform plugin at the exact core version. It validates identity, target OS, activation scope, and confirmation-gated adaptation rules. `doctor` remains read-only; no configuration, download, external install, or descriptor copy occurs.

The release workflow is serialized per tag and refuses an existing release before validation, build, attestation, or upload. No `--clobber` path remains.

## Validation

- repository validator: pass
- official plugin validator: 10/10
- official skill validator: 95/95
- unit tests: 113/113
- clean local Codex marketplace install: core 85 skills + Windows 1 + img2threejs 1, all v1.1.1
- installed Windows doctor from separate cache: exit 0, no project state, no descriptor copy, descriptor hash unchanged
- deterministic release: 16/16 artifacts identical across two builds
- extracted full archive repository validation: pass
- independent code review: no blockers

This patch preserves the published v1.1.0 tag and assets; v1.1.1 will be a new immutable hotfix release.