### PR TITLE
feat: build a verified contributor funnel

### DIFF
--- a/.github/ISSUE_TEMPLATE/contribution.yml
+++ b/.github/ISSUE_TEMPLATE/contribution.yml
@@ -1,0 +1,58 @@
+name: Contribution proposal
+description: Propose a larger or security-sensitive contribution before investing substantial work.
+title: "[Contribution]: "
+labels: [triage, needs-verification]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Small fixes and claimed good-first-issues can go directly to a pull request. Use this form for new integrations, executable automation, catalog batches, security-sensitive changes, or work whose scope needs agreement first.
+  - type: input
+    id: outcome
+    attributes:
+      label: User outcome
+      description: What concrete game-development outcome will this contribution improve?
+    validations:
+      required: true
+  - type: textarea
+    id: scope
+    attributes:
+      label: Proposed scope and paths
+      description: List the files or surfaces you expect to change and what will remain out of scope.
+    validations:
+      required: true
+  - type: dropdown
+    id: origin
+    attributes:
+      label: Origin
+      options:
+        - Original work
+        - Adapted third-party work
+        - AI-assisted work
+        - Mixed origin
+    validations:
+      required: true
+  - type: textarea
+    id: provenance
+    attributes:
+      label: Sources, immutable revisions, and licenses
+      description: List canonical URLs, full commit pins, licenses, transformations, and separate model/data/output terms. Write not applicable only for fully original work with no external assets.
+    validations:
+      required: true
+  - type: textarea
+    id: validation
+    attributes:
+      label: Validation and rollback plan
+      description: Describe tests, quality evidence, platform coverage, permissions, backups, and rollback where relevant.
+    validations:
+      required: true
+  - type: checkboxes
+    attributes:
+      label: Contributor checks
+      options:
+        - label: I read CONTRIBUTING.md, the DCO, and the Code of Conduct.
+          required: true
+        - label: I will not include credentials, private prompts, proprietary assets, or unconsented identity or voice material.
+          required: true
+        - label: I understand that maintainer agreement on scope does not guarantee merge; the pull request must still pass verification and review.
+          required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,6 +10,22 @@ Describe the user-visible result and the exact surfaces changed.
 - [ ] Windows, macOS, and Linux impact considered
 - [ ] Before/after screenshots or artifact evidence attached when visual output changed
 
+## Contributor certification and provenance
+
+- [ ] Every non-bot commit has my DCO 1.1 `Signed-off-by` line
+- [ ] I have the right to submit this contribution under the license that applies to the changed files
+- [ ] I personally reviewed any AI-assisted output and accept responsibility for its correctness, licensing, and safety
+- [ ] Third-party sources, immutable refs, licenses, destinations, and transformations are listed below or are not applicable
+- [ ] `NOTICE.md`, `UPSTREAM.json`, or the applicable provenance ledger was updated when required
+
+Origin: original / adapted / AI-assisted / mixed
+
+Tools used:
+
+Third-party sources and immutable refs:
+
+License and commercial-use findings:
+
 ## Safety and provenance
 
 - [ ] Detection remains read-only and every mutation begins with a plan

--- a/.github/dco.yml
+++ b/.github/dco.yml
@@ -1,0 +1,2 @@
+allowRemediationCommits:
+  individual: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes are recorded here. The project follows Semantic Versioning.
 
+## [Unreleased]
+
+### Added
+
+- DCO 1.1 certification, AI-assistance provenance fields, a contribution
+  proposal form, and a documented contributor verification path.
+- A focused README outcome, stable-install default, dynamic star badge, real
+  sprite QA evidence, and a 10-minute newcomer route.
+
+### Security
+
+- Repository validation now rejects privileged pull-request triggers, secrets
+  or broad write permissions in ordinary PR workflows, self-hosted fork jobs,
+  and checkout credentials that are not explicitly disabled.
+
 ## [1.1.1] - 2026-07-31
 
 ### Fixed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,50 @@
 
 Thanks for helping make AI-assisted game development safer and more reproducible. Contributions are welcome as issues, Discussions, documentation, catalog records, recipes, tests, or code.
 
+## Can I contribute?
+
+Yes. The project verifies the proposed change rather than using account age,
+followers, employer, or private identity as a trust score. External contributors
+work through forks and pull requests; only a maintainer can merge. Read the
+[contributor verification policy](docs/CONTRIBUTOR_VERIFICATION.md) for the exact
+automated, provenance, and human-review gates.
+
+## First contribution in 10 minutes
+
+1. Choose an open [`good first issue`](https://github.com/frabcd/codex-ai-game-studio/issues?q=is%3Aissue%20is%3Aopen%20label%3A%22good%20first%20issue%22) or a [`help wanted`](https://github.com/frabcd/codex-ai-game-studio/issues?q=is%3Aissue%20is%3Aopen%20label%3A%22help%20wanted%22) task. Comment before starting so two people do not duplicate work.
+2. Fork the repository, clone your fork, and create a focused branch from `main`.
+3. Make the smallest complete change that satisfies the issue's acceptance checks.
+4. Run `python tools/validate_repository.py` and the focused test named in the issue. The full standard-library suite usually completes without installing project dependencies.
+5. Commit with a DCO sign-off: `git commit -s -m "docs: describe the change"`.
+6. Open a pull request, complete the provenance section, and link the issue with `Closes #NUMBER`.
+
+Python 3.11 or newer and Git are sufficient for repository validation. Plugin or
+skill changes additionally need the pinned official validators used by CI.
+Large integrations or security-sensitive changes should start with the
+[contribution proposal form](https://github.com/frabcd/codex-ai-game-studio/issues/new?template=contribution.yml).
+
+## Certification, licensing, and AI assistance
+
+Every non-bot commit must certify the [Developer Certificate of Origin 1.1](DCO)
+with a `Signed-off-by` line:
+
+```text
+git commit -s -m "catalog: verify an engine adapter"
+```
+
+To repair the latest local commit, run `git commit --amend --no-edit --signoff`
+and then `git push --force-with-lease`. A sign-off certifies the right to submit;
+it does not transfer your copyright. Contributions remain under the license that
+applies to their destination: MIT for original project surfaces, Apache-2.0 for
+the retained img2threejs snapshot, or another license explicitly identified in
+the file.
+
+AI-assisted work is welcome when the contributor reviews it personally and
+accepts responsibility for the result. Disclose the tool or model when known and
+list relevant source material, licenses, immutable revisions, and transformations.
+Never submit private prompts, secret values, proprietary project content, or
+identity/voice material without the required rights and consent.
+
 ## Before opening a pull request
 
 1. Search existing issues and Discussions.

--- a/DCO
+++ b/DCO
@@ -1,0 +1,34 @@
+Developer Certificate of Origin
+Version 1.1
+
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.

--- a/README.md
+++ b/README.md
@@ -3,18 +3,26 @@
 ![Codex AI Game Studio: Plan. Generate. Validate. Ship.](assets/branding/hero.png)
 
 [![CI](https://github.com/frabcd/codex-ai-game-studio/actions/workflows/ci.yml/badge.svg)](https://github.com/frabcd/codex-ai-game-studio/actions/workflows/ci.yml)
-[![Catalog](https://img.shields.io/badge/catalog-163%20verified%20repositories-08C7F7)](plugins/ai-game-studio/catalog/catalog.json)
+[![GitHub stars](https://img.shields.io/github/stars/frabcd/codex-ai-game-studio?style=flat&logo=github&label=stars)](https://github.com/frabcd/codex-ai-game-studio/stargazers)
+[![Catalog](https://img.shields.io/badge/catalog-163%20curated%20repository%20records-08C7F7)](plugins/ai-game-studio/catalog/catalog.json)
 [![Skills](https://img.shields.io/badge/bundled%20Codex%20skills-95-7C5CFC)](plugins)
 [![Platforms](https://img.shields.io/badge/editions-Windows%20%7C%20macOS-08C7F7)](#choose-your-edition)
 [![License: MIT](https://img.shields.io/badge/core%20license-MIT-FFB347)](LICENSE)
 [![Release](https://img.shields.io/github/v/release/frabcd/codex-ai-game-studio)](https://github.com/frabcd/codex-ai-game-studio/releases)
 
-An installable, safety-first game-production system for Codex: **85 core
-skills, 95 bundled skills, 49 studio roles, 163 verified repositories, five
-editor MCP packs, and dedicated Windows and macOS editions**. It plans games,
-finds compatible AI tools, reconstructs reference images as quality-gated
-procedural Three.js models, generates and validates assets, automates supported
-engines, and keeps every setup reversible.
+Turn a game idea—or an existing Unity, Godot, Unreal, or browser project—into a
+**reversible, quality-gated Codex production workflow**. Codex AI Game Studio
+plans games, finds compatible AI tools, reconstructs reference images as
+procedural Three.js models, generates and validates assets, and automates
+supported editors without silently installing tools or replacing source work.
+
+Under the hood: **85 core skills, 95 bundled skills, 49 studio roles, 163
+curated repository records, five editor MCP packs, and dedicated Windows and
+macOS editions**.
+
+[Install in 60 seconds](#install) · [See a real quality gate](#see-a-quality-gate) · [Copy a production prompt](#what-should-i-say) · [Contribute in 10 minutes](CONTRIBUTING.md#first-contribution-in-10-minutes)
+
+If it earns a place in your workflow, [star the repository](https://github.com/frabcd/codex-ai-game-studio) so another game developer can find it. If something is missing, choose a scoped [`good first issue`](https://github.com/frabcd/codex-ai-game-studio/issues?q=is%3Aissue%20is%3Aopen%20label%3A%22good%20first%20issue%22) and improve it with us.
 
 ## Install
 
@@ -30,9 +38,12 @@ steps, and wait for my confirmation before changing anything.
 ```
 
 ```text
-codex plugin marketplace add frabcd/codex-ai-game-studio --ref main
+codex plugin marketplace add frabcd/codex-ai-game-studio --ref v1.1.1
 codex plugin add ai-game-studio@frabcd-ai-game-studio
 ```
+
+The command above pins the latest stable release. Contributors who intentionally
+want the development snapshot can use `--ref main` instead.
 
 [Install the core plugin in Codex](codex://plugins/install/ai-game-studio?marketplace=frabcd-ai-game-studio)
 
@@ -110,6 +121,19 @@ separate confirmed proposal.
 
 No catalog entry is automatically cloned, no model weights are silently downloaded, and no existing source asset is replaced without human approval.
 
+## See a quality gate
+
+This deterministic sprite fixture keeps the source pixels unchanged while the
+workflow detects baseline drift, loop seams, and inconsistent padding, produces
+a corrected candidate, and records human approval.
+
+![Deterministic sprite QA fixture showing a failed source and corrected candidate](assets/examples/sprite-before-after.png)
+
+[Inspect all representative QA fixtures](docs/EXAMPLES.md) or read the
+[current validation report](docs/VALIDATION.md). Production workflows apply the
+same evidence-first pattern to 3D topology, PBR materials, animation, audio,
+navigation, performance, visual regression, and playability.
+
 ## Four ways to invoke it
 
 | Surface | Use | Meaning |
@@ -133,7 +157,7 @@ See the official [Codex plugin guide](https://learn.chatgpt.com/docs/plugins) an
 - **Native platform editions:** Windows and macOS planners detect the real host
   and convert incompatible workflows through tested source adaptations or
   disclosed capability equivalents.
-- **Tool routing:** 163 curated GitHub repositories classified by capability, platform, runtime, GPU, licenses, permissions, risk, and maturity—usable offline.
+- **Tool routing:** 163 curated GitHub repository records classified by capability, platform, runtime, GPU, licenses, permissions, risk, and maturity—usable offline.
 - **Editor automation:** opt-in packs for Unity, Godot, Unreal, Blender, and pixel-art workflows, with one MCP server allowed per host application.
 - **Quality evidence:** technical checks, multi-view visual review, temporal consistency, performance budgets, playability smoke tests, provenance, and before/after artifacts.
 - **Codex-native parity:** 73 attributed workflows, 49 agent TOMLs, 12 mapped hook behaviors, 11 scoped rules, and 40 actual upstream templates from the pinned Claude Code Game Studios baseline, plus 12 new generative-game skills.
@@ -260,8 +284,6 @@ Specialized checks cover alpha and sprite baselines; mesh topology, normals, UVs
 
 See the [deterministic before/after and representative QA fixtures](docs/EXAMPLES.md) for inspectable evidence covering sprites, meshes, rigs, animation, audio, scenes, visual regression, and gameplay smoke tests.
 
-![Local release-candidate validation summary](assets/examples/validation-summary.svg)
-
 ## Offline catalog and live refresh
 
 The checked-in catalog is the final fallback and contains all 163 repositories from the verified source snapshot. Stable curation is separate from volatile stars, releases, archive state, and activity. Search order is:
@@ -323,7 +345,12 @@ recorded in [NOTICE.md](NOTICE.md) and
 
 ## Contributing and roadmap
 
-Issues, pull requests, and Discussions are welcome. Catalog changes require a canonical repository, verification evidence, separate license findings, platform claims, permission review, and a pin. Start with [CONTRIBUTING.md](CONTRIBUTING.md) and the catalog guide.
+Issues, pull requests, and Discussions are welcome. Start with the
+[10-minute contributor path](CONTRIBUTING.md#first-contribution-in-10-minutes),
+browse [`good first issue`](https://github.com/frabcd/codex-ai-game-studio/issues?q=is%3Aissue%20is%3Aopen%20label%3A%22good%20first%20issue%22), and read the
+[contributor verification policy](docs/CONTRIBUTOR_VERIFICATION.md). Catalog
+changes require a canonical repository, primary-source evidence, separate
+license findings, platform claims, permission review, and an immutable pin.
 
 If this saves your team a production detour, starring the repository helps other game developers find the maintained catalog. Useful contributions matter more: add a verified integration, improve a recipe gate, or attach a reproducible QA fixture.
 

--- a/docs/CONTRIBUTOR_VERIFICATION.md
+++ b/docs/CONTRIBUTOR_VERIFICATION.md
@@ -1,0 +1,91 @@
+# Contributor verification
+
+Codex AI Game Studio verifies **contributions**, not private identities. Anyone
+who follows the Code of Conduct may propose a change. Account age, follower
+count, location, employer, and popularity are not acceptance criteria, and the
+project never asks contributors for government ID, credentials, private prompts,
+or secret values.
+
+## The verification path
+
+| Stage | What is checked | Result |
+|---|---|---|
+| Before CI | A maintainer inspects every external fork change before allowing workflows to run | Untrusted code never runs automatically merely because an account contributed before |
+| Certification | Every non-bot commit carries a DCO 1.1 `Signed-off-by` line | The contributor certifies the right to submit the work under the applicable license |
+| Automated checks | Read-only CI validates repository contracts, pins, links, tests, releases, and common secret or unsafe-command patterns | Objective failures are visible on the pull request |
+| Provenance review | Sources, immutable revisions, licenses, AI assistance, model/data/output terms, identity or voice consent, and transformations are reviewed where applicable | Unknown rights block merge rather than being guessed |
+| Maintainer review | Scope, correctness, platform claims, safety boundaries, quality evidence, and sensitive paths are reviewed | Only a repository maintainer can merge |
+
+A DCO is a rights declaration, not a background check or a guarantee that code
+is safe. Passing it does not replace code review, provenance review, CI, or human
+judgment.
+
+## Fork workflow boundary
+
+Pull-request workflows use the ordinary `pull_request` event with read-only
+repository permissions. They do not use `pull_request_target` or privileged
+`workflow_run` handoffs, expose secrets, persist checkout credentials, or run
+fork code on self-hosted machines. Third-party Actions are pinned to full commit
+SHAs. GitHub's repository policy requires approval before workflows from any
+external fork run.
+
+The repository validator rejects regressions in these controls. CodeQL's narrow
+`security-events: write` permission is the only write permission allowed in an
+ordinary pull-request workflow.
+
+## DCO sign-off
+
+Read [DCO](../DCO), then add a sign-off using the name and email associated with
+your commit:
+
+```text
+git commit -s -m "docs: clarify the Godot quickstart"
+```
+
+To repair the latest local commit:
+
+```text
+git commit --amend --no-edit --signoff
+git push --force-with-lease
+```
+
+For several commits, use an interactive rebase and amend each one. Do not paste
+another person's sign-off. The repository-side DCO policy is ready for the
+[DCO GitHub App](https://github.com/apps/dco); until its check is enabled and
+made required, the maintainer reviews sign-offs manually.
+
+## AI-assisted and adapted work
+
+AI assistance is allowed, but the submitting human remains responsible for the
+result. In the pull request:
+
+- State whether the work is original, adapted, AI-assisted, or a combination.
+- Name the tool or model when known; never include private prompts or tokens.
+- List every relevant third-party source, canonical URL, immutable revision,
+  license, destination, and transformation.
+- Record code, model-weight, dataset, generated-output, and commercial-use terms
+  separately when those surfaces exist.
+- Confirm the result was reviewed and tested by a human.
+- Provide consent evidence for identity or voice work without publishing private
+  personal data.
+
+Unknown or incompatible rights, unverifiable consent, credential material, or a
+request to bypass the inspect/plan/confirm/rollback contract blocks merge.
+
+## Sensitive paths
+
+Changes to workflows, hooks, release tooling, pack descriptors, executable
+scripts, security policy, licenses, catalog curation, or provenance ledgers need
+explicit maintainer review. A first-time contributor may change them, but the
+evidence and review burden is intentionally higher.
+
+Direct write or merge access is never granted automatically. It is considered
+only after sustained, constructive contributions and a separate maintainer
+decision.
+
+## What contributors can expect
+
+The maintainer aims to acknowledge a pull request within three business days,
+even when a full review takes longer. If a contribution does not fit, the reason
+should be recorded publicly and respectfully. Security reports and Code of
+Conduct reports remain private through their dedicated channels.

--- a/tests/test_repository_pages.py
+++ b/tests/test_repository_pages.py
@@ -1,13 +1,21 @@
 from __future__ import annotations
 
 import html
+import json
 from pathlib import Path
 import re
 import tempfile
 import unittest
 from urllib.parse import urlsplit
+import xml.etree.ElementTree as ET
 
-from tools.build_pages import build, markdown_to_html, split_frontmatter
+from tools.build_pages import (
+    SITE_DESCRIPTION,
+    SITE_URL,
+    build,
+    markdown_to_html,
+    split_frontmatter,
+)
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -44,6 +52,8 @@ class PagesBuilderTests(unittest.TestCase):
                 "platforms/windows/index.html",
                 "platforms/macos/index.html",
                 "assets/site.css",
+                "sitemap.xml",
+                "robots.txt",
                 ".nojekyll",
             ):
                 self.assertIn(expected, relative)
@@ -63,6 +73,96 @@ class PagesBuilderTests(unittest.TestCase):
                 'href="/codex-ai-game-studio/packs/img2threejs/"',
                 pack_index,
             )
+
+    def test_pages_include_canonical_social_and_structured_metadata(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="ags-pages-metadata-") as temporary:
+            output_root = Path(temporary).resolve()
+            build(ROOT, output_root)
+            home = (output_root / "index.html").read_text(encoding="utf-8")
+            tutorial = (output_root / "tutorials" / "index.html").read_text(encoding="utf-8")
+
+            self.assertIn(f'<link rel="canonical" href="{SITE_URL}/">', home)
+            self.assertIn(
+                f'<link rel="canonical" href="{SITE_URL}/tutorials/">',
+                tutorial,
+            )
+            self.assertIn(f'<meta property="og:url" content="{SITE_URL}/">', home)
+            self.assertIn(
+                f'<meta property="og:image" content="{SITE_URL}/assets/branding/hero.png">',
+                home,
+            )
+            self.assertIn('<meta name="twitter:card" content="summary_large_image">', home)
+            self.assertIn(
+                '<link rel="icon" type="image/png" '
+                'href="/codex-ai-game-studio/assets/branding/icon.png">',
+                home,
+            )
+            self.assertIn(f'<meta name="description" content="{SITE_DESCRIPTION}">', home)
+
+            match = re.search(
+                r'<script type="application/ld\+json">(.+)</script>',
+                tutorial,
+            )
+            self.assertIsNotNone(match)
+            metadata = json.loads(match.group(1))
+            self.assertEqual(metadata["@type"], "SoftwareSourceCode")
+            self.assertEqual(
+                metadata["codeRepository"],
+                "https://github.com/frabcd/codex-ai-game-studio",
+            )
+            self.assertEqual(metadata["mainEntityOfPage"], f"{SITE_URL}/tutorials/")
+
+    def test_sitemap_and_robots_cover_generated_routes_deterministically(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="ags-pages-discovery-") as temporary:
+            output_root = Path(temporary).resolve()
+            written = build(ROOT, output_root)
+            generated_pages = sorted(
+                path.relative_to(output_root).as_posix()
+                for path in written
+                if path.name == "index.html"
+            )
+            expected_urls = [
+                f"{SITE_URL}/"
+                if relative == "index.html"
+                else f"{SITE_URL}/{relative.removesuffix('index.html')}"
+                for relative in generated_pages
+            ]
+
+            sitemap_path = output_root / "sitemap.xml"
+            root = ET.fromstring(sitemap_path.read_text(encoding="utf-8"))
+            namespace = {"sitemap": "http://www.sitemaps.org/schemas/sitemap/0.9"}
+            actual_urls = [
+                element.text
+                for element in root.findall("sitemap:url/sitemap:loc", namespace)
+            ]
+            self.assertEqual(sorted(expected_urls), actual_urls)
+            self.assertEqual(len(actual_urls), len(set(actual_urls)))
+
+            self.assertEqual(
+                "User-agent: *\n"
+                "Allow: /codex-ai-game-studio/\n"
+                f"Sitemap: {SITE_URL}/sitemap.xml\n",
+                (output_root / "robots.txt").read_text(encoding="utf-8"),
+            )
+
+    def test_build_content_is_deterministic(self) -> None:
+        with (
+            tempfile.TemporaryDirectory(prefix="ags-pages-first-") as first,
+            tempfile.TemporaryDirectory(prefix="ags-pages-second-") as second,
+        ):
+            first_root = Path(first).resolve()
+            second_root = Path(second).resolve()
+            build(ROOT, first_root)
+            build(ROOT, second_root)
+
+            def contents(root: Path) -> dict[str, bytes]:
+                return {
+                    path.relative_to(root).as_posix(): path.read_bytes()
+                    for path in sorted(root.rglob("*"))
+                    if path.is_file()
+                }
+
+            self.assertEqual(contents(first_root), contents(second_root))
 
     def test_every_generated_internal_link_resolves(self) -> None:
         with tempfile.TemporaryDirectory(prefix="ags-pages-crawl-") as temporary:

--- a/tests/test_repository_security.py
+++ b/tests/test_repository_security.py
@@ -65,6 +65,97 @@ class RepositorySecurityTests(unittest.TestCase):
             self.assertIn("release-mutable-assets", codes)
             self.assertIn("release-immutability-guard", codes)
 
+    def test_workflow_scan_rejects_privileged_pr_triggers(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="ags-privileged-pr-") as temporary:
+            root = Path(temporary)
+            workflows = root / ".github" / "workflows"
+            workflows.mkdir(parents=True)
+            (workflows / "target.yml").write_text("on:\n  pull_request_target:\n", encoding="utf-8")
+            (workflows / "handoff.yml").write_text("on:\n  workflow_run:\n", encoding="utf-8")
+            validator = Validator(root)
+            validator.validate_workflows()
+            codes = {problem.code for problem in validator.problems}
+            self.assertIn("workflow-privileged-pr", codes)
+            self.assertIn("workflow-privileged-handoff", codes)
+
+    def test_workflow_scan_rejects_unsafe_fork_permissions_and_runner(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="ags-fork-workflow-") as temporary:
+            root = Path(temporary)
+            workflows = root / ".github" / "workflows"
+            workflows.mkdir(parents=True)
+            (workflows / "unsafe.yml").write_text(
+                "on:\n"
+                "  pull_request:\n"
+                "permissions:\n"
+                "  contents: write\n"
+                "jobs:\n"
+                "  unsafe:\n"
+                "    runs-on: [self-hosted, linux]\n"
+                "    steps:\n"
+                "      - run: echo '${{ secrets.PRIVATE_TOKEN }}'\n",
+                encoding="utf-8",
+            )
+            validator = Validator(root)
+            validator.validate_workflows()
+            codes = {problem.code for problem in validator.problems}
+            self.assertIn("workflow-pr-secret", codes)
+            self.assertIn("workflow-pr-self-hosted", codes)
+            self.assertIn("workflow-pr-write", codes)
+
+    def test_workflow_scan_requires_checkout_credentials_to_be_disabled(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="ags-checkout-workflow-") as temporary:
+            root = Path(temporary)
+            workflows = root / ".github" / "workflows"
+            workflows.mkdir(parents=True)
+            (workflows / "checkout.yml").write_text(
+                "on:\n"
+                "  pull_request:\n"
+                "permissions:\n"
+                "  contents: read\n"
+                "jobs:\n"
+                "  validate:\n"
+                "    runs-on: ubuntu-latest\n"
+                "    steps:\n"
+                "      - name: Checkout\n"
+                "        uses: actions/checkout@" + "1" * 40 + "\n",
+                encoding="utf-8",
+            )
+            validator = Validator(root)
+            validator.validate_workflows()
+            codes = {problem.code for problem in validator.problems}
+            self.assertIn("workflow-checkout-credentials", codes)
+
+    def test_workflow_scan_allows_read_only_pr_and_codeql_permission(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="ags-safe-pr-workflow-") as temporary:
+            root = Path(temporary)
+            workflows = root / ".github" / "workflows"
+            workflows.mkdir(parents=True)
+            (workflows / "codeql.yml").write_text(
+                "on:\n"
+                "  pull_request:\n"
+                "permissions:\n"
+                "  contents: read\n"
+                "  security-events: write\n"
+                "jobs:\n"
+                "  analyze:\n"
+                "    runs-on: ubuntu-latest\n"
+                "    steps:\n"
+                "      - name: Checkout\n"
+                "        uses: actions/checkout@" + "1" * 40 + "\n"
+                "        with:\n"
+                "          persist-credentials: false\n",
+                encoding="utf-8",
+            )
+            validator = Validator(root)
+            validator.validate_workflows()
+            blocked = {
+                "workflow-pr-secret",
+                "workflow-pr-self-hosted",
+                "workflow-pr-write",
+                "workflow-checkout-credentials",
+            }
+            self.assertFalse(blocked & {problem.code for problem in validator.problems})
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tools/build_pages.py
+++ b/tools/build_pages.py
@@ -5,14 +5,25 @@ from __future__ import annotations
 
 import argparse
 import html
+import json
 from pathlib import Path
 import re
 import shutil
 from urllib.parse import quote
+from xml.sax.saxutils import escape as xml_escape
 
 
 SITE_BASE = "/codex-ai-game-studio"
+SITE_ORIGIN = "https://frabcd.github.io"
+SITE_URL = f"{SITE_ORIGIN}{SITE_BASE}"
+SITE_NAME = "Codex AI Game Studio"
+SITE_DESCRIPTION = (
+    "A Codex-native AI game development studio with skills, curated tool routing, "
+    "reversible automation, and production quality gates."
+)
 GITHUB_SOURCE = "https://github.com/frabcd/codex-ai-game-studio"
+SOCIAL_IMAGE_URL = f"{SITE_URL}/assets/branding/hero.png"
+FAVICON_PATH = f"{SITE_BASE}/assets/branding/icon.png"
 IMAGE = re.compile(r"!\[([^\]]*)\]\(([^)]+)\)")
 LINK = re.compile(r"(?<!!)\[([^\]]+)\]\(([^)]+)\)")
 IMAGE_LINK = re.compile(r"\[(!\[[^\]]*\]\([^)]+\))\]\(([^)]+)\)")
@@ -206,15 +217,66 @@ def markdown_to_html(source: str) -> str:
     return "\n".join(output)
 
 
-def page(title: str, body: str) -> str:
+def canonical_url(route: str) -> str:
+    """Return the public trailing-slash URL for a generated route."""
+
+    normalized = route.strip("/")
+    return f"{SITE_URL}/{normalized}/" if normalized else f"{SITE_URL}/"
+
+
+def structured_data(canonical: str) -> str:
+    """Return deterministic JSON-LD describing the repository behind the site."""
+
+    payload = {
+        "@context": "https://schema.org",
+        "@type": "SoftwareSourceCode",
+        "name": SITE_NAME,
+        "description": SITE_DESCRIPTION,
+        "url": f"{SITE_URL}/",
+        "mainEntityOfPage": canonical,
+        "codeRepository": GITHUB_SOURCE,
+        "license": f"{GITHUB_SOURCE}/blob/main/LICENSE",
+        "image": SOCIAL_IMAGE_URL,
+        "programmingLanguage": ["Python", "PowerShell", "Shell"],
+        "runtimePlatform": ["Codex CLI", "Codex desktop"],
+        "author": {
+            "@type": "Person",
+            "name": "frabcd",
+            "url": "https://github.com/frabcd",
+        },
+    }
+    return json.dumps(payload, ensure_ascii=False, separators=(",", ":")).replace("</", "<\\/")
+
+
+def page(title: str, body: str, route: str = "") -> str:
+    canonical = canonical_url(route)
+    document_title = SITE_NAME if title == SITE_NAME else f"{title} · {SITE_NAME}"
+    escaped_title = html.escape(document_title, quote=True)
+    escaped_description = html.escape(SITE_DESCRIPTION, quote=True)
+    escaped_canonical = html.escape(canonical, quote=True)
+    escaped_image = html.escape(SOCIAL_IMAGE_URL, quote=True)
     return f"""<!doctype html>
 <html lang="en">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="description" content="Codex AI Game Studio documentation">
-  <title>{html.escape(title)} · Codex AI Game Studio</title>
-  <link rel="stylesheet" href="/codex-ai-game-studio/assets/site.css">
+  <meta name="description" content="{escaped_description}">
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="{SITE_NAME}">
+  <meta property="og:title" content="{escaped_title}">
+  <meta property="og:description" content="{escaped_description}">
+  <meta property="og:url" content="{escaped_canonical}">
+  <meta property="og:image" content="{escaped_image}">
+  <meta property="og:image:alt" content="Codex AI Game Studio workflow overview">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="{escaped_title}">
+  <meta name="twitter:description" content="{escaped_description}">
+  <meta name="twitter:image" content="{escaped_image}">
+  <link rel="canonical" href="{escaped_canonical}">
+  <link rel="icon" type="image/png" href="{FAVICON_PATH}">
+  <link rel="stylesheet" href="{SITE_BASE}/assets/site.css">
+  <script type="application/ld+json">{structured_data(canonical)}</script>
+  <title>{escaped_title}</title>
 </head>
 <body>
   <header><a class="brand" href="/codex-ai-game-studio/">Codex AI Game Studio</a>
@@ -253,7 +315,34 @@ def write_page(
     target = output / route / "index.html" if route else output / "index.html"
     target.parent.mkdir(parents=True, exist_ok=True)
     title = metadata.get("title") or title_from(body, source_path.stem)
-    target.write_text(page(title, markdown_to_html(body)), encoding="utf-8", newline="\n")
+    target.write_text(page(title, markdown_to_html(body), route), encoding="utf-8", newline="\n")
+
+
+def write_discovery_files(output: Path, routes: list[str]) -> list[Path]:
+    """Write deterministic files used by search engines and other crawlers."""
+
+    sitemap = output / "sitemap.xml"
+    locations = "\n".join(
+        f"  <url><loc>{xml_escape(canonical_url(route))}</loc></url>"
+        for route in sorted(routes)
+    )
+    sitemap.write_text(
+        '<?xml version="1.0" encoding="UTF-8"?>\n'
+        '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n'
+        f"{locations}\n"
+        "</urlset>\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+    robots = output / "robots.txt"
+    robots.write_text(
+        "User-agent: *\n"
+        f"Allow: {SITE_BASE}/\n"
+        f"Sitemap: {SITE_URL}/sitemap.xml\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+    return [sitemap, robots]
 
 
 def build(root: Path, output: Path) -> list[Path]:
@@ -312,6 +401,8 @@ def build(root: Path, output: Path) -> list[Path]:
     for route, source in pages:
         write_page(output, route, source, root=root, routes=routes)
         written.append(output / route / "index.html")
+
+    written.extend(write_discovery_files(output, [route for route, _ in pages]))
 
     assets = output / "assets"
     assets.mkdir(parents=True, exist_ok=True)

--- a/tools/validate_repository.py
+++ b/tools/validate_repository.py
@@ -871,6 +871,72 @@ class Validator:
             self.error("workflow-set", workflow_root, f"missing workflows {sorted(expected-names)}")
         for path in workflow_files:
             text = path.read_text(encoding="utf-8")
+            if re.search(r"\bpull_request_target\b", text):
+                self.error(
+                    "workflow-privileged-pr",
+                    path,
+                    "pull_request_target is forbidden; use a read-only pull_request workflow",
+                )
+            if re.search(r"\bworkflow_run\b", text):
+                self.error(
+                    "workflow-privileged-handoff",
+                    path,
+                    "workflow_run handoffs are forbidden because fork artifacts and code are untrusted",
+                )
+
+            pull_request_workflow = bool(
+                re.search(r"(?m)^\s*pull_request\s*:", text)
+                or re.search(r"(?m)^\s*on\s*:\s*\[[^\]]*\bpull_request\b", text)
+                or re.search(r"(?m)^\s*on\s*:\s*\{[^}]*\bpull_request\s*:", text)
+            )
+            if pull_request_workflow:
+                if re.search(r"\$\{\{\s*secrets\.", text):
+                    self.error(
+                        "workflow-pr-secret",
+                        path,
+                        "ordinary pull-request workflows must not reference repository secrets",
+                    )
+                if re.search(r"(?im)^\s*runs-on\s*:\s*(?:\[[^\]]*)?\bself-hosted\b", text):
+                    self.error(
+                        "workflow-pr-self-hosted",
+                        path,
+                        "fork pull requests must run only on isolated GitHub-hosted runners",
+                    )
+                if re.search(r"(?im)^\s*permissions\s*:\s*write-all\s*$", text):
+                    self.error(
+                        "workflow-pr-write",
+                        path,
+                        "pull-request workflows must use explicit read-only permissions",
+                    )
+                for permission in re.findall(r"(?m)^\s*([A-Za-z0-9_-]+)\s*:\s*write\s*(?:#.*)?$", text):
+                    if path.name == "codeql.yml" and permission == "security-events":
+                        continue
+                    self.error(
+                        "workflow-pr-write",
+                        path,
+                        f"pull-request workflow requests {permission}: write",
+                    )
+
+            lines = text.splitlines()
+            for line_number, line in enumerate(lines):
+                if not re.search(r"\buses:\s*actions/checkout@", line):
+                    continue
+                uses_indent = len(line) - len(line.lstrip())
+                step_indent = max(0, uses_indent - (0 if line.lstrip().startswith("- uses:") else 2))
+                checkout_block: list[str] = []
+                for following in lines[line_number + 1 :]:
+                    stripped = following.lstrip()
+                    following_indent = len(following) - len(stripped)
+                    if stripped.startswith("- ") and following_indent <= step_indent:
+                        break
+                    checkout_block.append(following)
+                if not any(re.search(r"^\s*persist-credentials\s*:\s*false\s*(?:#.*)?$", item) for item in checkout_block):
+                    self.error(
+                        "workflow-checkout-credentials",
+                        path,
+                        "every actions/checkout step must set persist-credentials: false",
+                    )
+
             for use in ACTION_USE.findall(text):
                 if use.startswith("./"):
                     resolved = safe_resolve(self.root, use)


### PR DESCRIPTION
## Outcome

Make the repository easier to understand, discover, and contribute to while strengthening the trust boundary for external pull requests.

## Why

The repository already had a 100% GitHub community profile and broad CI, but it had no public starter backlog, no short first-contribution path, missing labels referenced by automation, no contribution-rights certification, and limited Pages search/social metadata. Current growth guidance favors a visible outcome, real evidence, scoped starter work, fast public feedback, and safe automation over link spam.

## Changes

- Reframes the README around one user outcome, pins the stable install, adds a dynamic star badge, and surfaces a real sprite QA before/after.
- Adds DCO 1.1, AI-assisted/adapted-work provenance fields, a contribution proposal form, and a documented verification path.
- Expands repository validation to reject `pull_request_target`, privileged `workflow_run` handoffs, PR secrets, broad write permissions, self-hosted fork jobs, and persisted checkout credentials.
- Adds canonical URLs, Open Graph/Twitter metadata, favicon, JSON-LD `SoftwareSourceCode`, deterministic `sitemap.xml`, and `robots.txt` to the custom Pages build.
- Adds focused regression tests and an unreleased changelog entry.

## Impact and safety

External contributors are evaluated on their changes—not account popularity or private identity. Fork workflows stay read-only, secret-free, SHA-pinned, and GitHub-hosted. DCO certifies submission rights but does not replace provenance, CI, or maintainer review.

The repository settings were also updated separately to require approval for every external fork run, require web commit sign-off, require full-SHA Action pins, prevent Actions from approving PRs, and create the labels referenced by forms and automation.

## Verification

- [x] `python tools/validate_repository.py`
- [x] 120/120 standard-library tests
- [x] 10/10 official plugin validations
- [x] 95/95 official skill validations
- [x] Pages metadata, sitemap, robots, internal-link, and deterministic-build tests
- [x] Negative workflow-security fixtures
- [x] `git diff --check`
- [x] Windows, macOS, and Linux impact considered

## Contributor certification and provenance

- [x] Commit contains my DCO 1.1 `Signed-off-by` line
- [x] I have the right to submit this contribution under the applicable licenses
- [x] AI-assisted output was personally reviewed for correctness, licensing, and safety
- [x] Third-party source is limited to the verbatim DCO 1.1 text, whose official notice permits verbatim redistribution
- [x] No credentials, private prompts, proprietary assets, or unconsented identity/voice material are included

Origin: AI-assisted original work plus verbatim DCO 1.1 text

Tools used: OpenAI Codex

Third-party source: https://developercertificate.org/

License findings: original project changes remain MIT; the DCO document retains its own verbatim-copy notice; no plugin or vendored runtime license changed.